### PR TITLE
Show deletion queue associated to given job

### DIFF
--- a/frontend/src/components/JsonModal.js
+++ b/frontend/src/components/JsonModal.js
@@ -1,0 +1,24 @@
+import React from "react";
+import ReactJson from "react-json-view";
+import { Button, Modal } from "react-bootstrap";
+
+export default ({ object, onHide, show, title }) => (
+  <Modal centered show={show} size="lg" onHide={onHide}>
+    <Modal.Header closeButton>
+      <Modal.Title>{title}</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <ReactJson
+        displayDataTypes={false}
+        indentWidth={2}
+        name={false}
+        src={object}
+      />
+    </Modal.Body>
+    <Modal.Footer>
+      <Button className="aws-button cancel" onClick={onHide}>
+        Close
+      </Button>
+    </Modal.Footer>
+  </Modal>
+);


### PR DESCRIPTION
Note: I avoided calling that "Matches" because it *could* wrongly imply that those matchIds where actually matched during that job. So I just called it "Deletion Queue" as it was more generic. I wonder if we should do the same for the API?

![Screenshot 2020-02-18 at 12 09 49](https://user-images.githubusercontent.com/1789893/74735039-c89b5480-5247-11ea-8873-43c3c9a91026.png)
![Screenshot 2020-02-18 at 12 09 56](https://user-images.githubusercontent.com/1789893/74735047-cb964500-5247-11ea-9e7e-4cc6510bb7cf.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
