### PR TITLE
API versioning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
     rev: v0.28.2
     hooks:
     -   id: cfn-python-lint
-        args: [--ignore-templates=api.defintion.yml]
+        args: [--ignore-templates=templates/api.definition.yml]
         files: >-
             templates/.*\.(json|yml|yaml|template)$

--- a/docs/api/Apis/DataMapperApi.md
+++ b/docs/api/Apis/DataMapperApi.md
@@ -4,9 +4,9 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**CreateDataMapper**](DataMapperApi.md#createdatamapper) | **PUT** /data_mappers/{data_mapper_id} | Creates a data mapper
-[**DeleteDataMapper**](DataMapperApi.md#deletedatamapper) | **DELETE** /data_mappers/{data_mapper_id} | Removes a data mapper
-[**ListDataMappers**](DataMapperApi.md#listdatamappers) | **GET** /data_mappers | Lists data mappers
+[**CreateDataMapper**](DataMapperApi.md#createdatamapper) | **PUT** /v1/data_mappers/{data_mapper_id} | Creates a data mapper
+[**DeleteDataMapper**](DataMapperApi.md#deletedatamapper) | **DELETE** /v1/data_mappers/{data_mapper_id} | Removes a data mapper
+[**ListDataMappers**](DataMapperApi.md#listdatamappers) | **GET** /v1/data_mappers | Lists data mappers
 
 
 <a name="createdatamapper"></a>

--- a/docs/api/Apis/DeletionQueueApi.md
+++ b/docs/api/Apis/DeletionQueueApi.md
@@ -4,10 +4,10 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**AddToDeletionQueue**](DeletionQueueApi.md#addtodeletionqueue) | **PATCH** /queue | Adds an item to the deletion queue
-[**DeleteMatches**](DeletionQueueApi.md#deletematches) | **DELETE** /queue/matches | Removes an item from the deletion queue
-[**ListDeletionQueueMatches**](DeletionQueueApi.md#listdeletionqueuematches) | **GET** /queue | Lists deletion queue items
-[**StartDeletionJob**](DeletionQueueApi.md#startdeletionjob) | **DELETE** /queue | Starts a job for the items in the deletion queue
+[**AddToDeletionQueue**](DeletionQueueApi.md#addtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue
+[**DeleteMatches**](DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes an item from the deletion queue
+[**ListDeletionQueueMatches**](DeletionQueueApi.md#listdeletionqueuematches) | **GET** /v1/queue | Lists deletion queue items
+[**StartDeletionJob**](DeletionQueueApi.md#startdeletionjob) | **DELETE** /v1/queue | Starts a job for the items in the deletion queue
 
 
 <a name="addtodeletionqueue"></a>

--- a/docs/api/Apis/JobApi.md
+++ b/docs/api/Apis/JobApi.md
@@ -4,9 +4,9 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**GetJob**](JobApi.md#getjob) | **GET** /jobs/{job_id} | Returns the details of a job
-[**GetJobEvents**](JobApi.md#getjobevents) | **GET** /jobs/{job_id}/events | Lists all events for a job
-[**ListJobs**](JobApi.md#listjobs) | **GET** /jobs | Lists all jobs
+[**GetJob**](JobApi.md#getjob) | **GET** /v1/jobs/{job_id} | Returns the details of a job
+[**GetJobEvents**](JobApi.md#getjobevents) | **GET** /v1/jobs/{job_id}/events | Lists all events for a job
+[**ListJobs**](JobApi.md#listjobs) | **GET** /v1/jobs | Lists all jobs
 
 
 <a name="getjob"></a>

--- a/docs/api/Apis/SettingsApi.md
+++ b/docs/api/Apis/SettingsApi.md
@@ -4,7 +4,7 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**GetSettings**](SettingsApi.md#getsettings) | **GET** /settings | Gets the solution settings
+[**GetSettings**](SettingsApi.md#getsettings) | **GET** /v1/settings | Gets the solution settings
 
 
 <a name="getsettings"></a>

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -7,17 +7,17 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 API | Operation | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*DataMapperApi* | [**CreateDataMapper**](./Apis/DataMapperApi.md#createdatamapper) | **PUT** /data_mappers/{data_mapper_id} | Creates a data mapper
-*DataMapperApi* | [**DeleteDataMapper**](./Apis/DataMapperApi.md#deletedatamapper) | **DELETE** /data_mappers/{data_mapper_id} | Removes a data mapper
-*DataMapperApi* | [**ListDataMappers**](./Apis/DataMapperApi.md#listdatamappers) | **GET** /data_mappers | Lists data mappers
-*DeletionQueueApi* | [**AddToDeletionQueue**](./Apis/DeletionQueueApi.md#addtodeletionqueue) | **PATCH** /queue | Adds an item to the deletion queue
-*DeletionQueueApi* | [**DeleteMatches**](./Apis/DeletionQueueApi.md#deletematches) | **DELETE** /queue/matches | Removes an item from the deletion queue
-*DeletionQueueApi* | [**ListDeletionQueueMatches**](./Apis/DeletionQueueApi.md#listdeletionqueuematches) | **GET** /queue | Lists deletion queue items
-*DeletionQueueApi* | [**StartDeletionJob**](./Apis/DeletionQueueApi.md#startdeletionjob) | **DELETE** /queue | Starts a job for the items in the deletion queue
-*JobApi* | [**GetJob**](./Apis/JobApi.md#getjob) | **GET** /jobs/{job_id} | Returns the details of a job
-*JobApi* | [**GetJobEvents**](./Apis/JobApi.md#getjobevents) | **GET** /jobs/{job_id}/events | Lists all events for a job
-*JobApi* | [**ListJobs**](./Apis/JobApi.md#listjobs) | **GET** /jobs | Lists all jobs
-*SettingsApi* | [**GetSettings**](./Apis/SettingsApi.md#getsettings) | **GET** /settings | Gets the solution settings
+*DataMapperApi* | [**CreateDataMapper**](./Apis/DataMapperApi.md#createdatamapper) | **PUT** /v1/data_mappers/{data_mapper_id} | Creates a data mapper
+*DataMapperApi* | [**DeleteDataMapper**](./Apis/DataMapperApi.md#deletedatamapper) | **DELETE** /v1/data_mappers/{data_mapper_id} | Removes a data mapper
+*DataMapperApi* | [**ListDataMappers**](./Apis/DataMapperApi.md#listdatamappers) | **GET** /v1/data_mappers | Lists data mappers
+*DeletionQueueApi* | [**AddToDeletionQueue**](./Apis/DeletionQueueApi.md#addtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue
+*DeletionQueueApi* | [**DeleteMatches**](./Apis/DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes an item from the deletion queue
+*DeletionQueueApi* | [**ListDeletionQueueMatches**](./Apis/DeletionQueueApi.md#listdeletionqueuematches) | **GET** /v1/queue | Lists deletion queue items
+*DeletionQueueApi* | [**StartDeletionJob**](./Apis/DeletionQueueApi.md#startdeletionjob) | **DELETE** /v1/queue | Starts a job for the items in the deletion queue
+*JobApi* | [**GetJob**](./Apis/JobApi.md#getjob) | **GET** /v1/jobs/{job_id} | Returns the details of a job
+*JobApi* | [**GetJobEvents**](./Apis/JobApi.md#getjobevents) | **GET** /v1/jobs/{job_id}/events | Lists all events for a job
+*JobApi* | [**ListJobs**](./Apis/JobApi.md#listjobs) | **GET** /v1/jobs | Lists all jobs
+*SettingsApi* | [**GetSettings**](./Apis/SettingsApi.md#getsettings) | **GET** /v1/settings | Gets the solution settings
 
 
 <a name="documentation-for-models"></a>

--- a/frontend/src/utils/request.js
+++ b/frontend/src/utils/request.js
@@ -23,7 +23,7 @@ Amplify.configure({
     endpoints: [
       {
         name: "apiGateway",
-        endpoint: settings.apiUrl,
+        endpoint: `${settings.apiUrl}v1/`,
         region,
         custom_header: async () => {
           const session = await Auth.currentSession();

--- a/templates/api.definition.yml
+++ b/templates/api.definition.yml
@@ -17,7 +17,7 @@ tags:
   - name: Settings
     description: Operations related to solution settings
 paths:
-  /queue:
+  /v1/queue:
     get:
       summary: Lists deletion queue items
       tags:
@@ -96,7 +96,7 @@ paths:
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"
-  /queue/matches:
+  /v1/queue/matches:
     delete:
       summary: Removes an item from the deletion queue
       tags:
@@ -140,7 +140,7 @@ paths:
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"
-  /jobs:
+  /v1/jobs:
     get:
       summary: Lists all jobs
       tags:
@@ -176,7 +176,7 @@ paths:
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"
-  /jobs/{job_id}:
+  /v1/jobs/{job_id}:
     parameters:
       - '$ref': '#/components/parameters/JobId'
     get:
@@ -199,7 +199,7 @@ paths:
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"
-  /jobs/{job_id}/events:
+  /v1/jobs/{job_id}/events:
     parameters:
       - '$ref': '#/components/parameters/JobId'
     get:
@@ -237,7 +237,7 @@ paths:
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"
-  /data_mappers:
+  /v1/data_mappers:
     get:
       summary: Lists data mappers
       tags:
@@ -265,7 +265,7 @@ paths:
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"
-  /data_mappers/{data_mapper_id}:
+  /v1/data_mappers/{data_mapper_id}:
     parameters:
       - '$ref': '#/components/parameters/DataMapperId'
     put:
@@ -311,7 +311,7 @@ paths:
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"
-  /settings:
+  /v1/settings:
     get:
       summary: Gets the solution settings
       tags:

--- a/templates/api.yaml
+++ b/templates/api.yaml
@@ -132,7 +132,7 @@ Resources:
         Get:
           Type: Api
           Properties:
-            Path: /queue
+            Path: /v1/queue
             Method: PATCH
             RestApiId: !Ref Api
       Policies:
@@ -147,7 +147,7 @@ Resources:
         Get:
           Type: Api
           Properties:
-            Path: /queue
+            Path: /v1/queue
             Method: GET
             RestApiId: !Ref Api
       Policies:
@@ -162,7 +162,7 @@ Resources:
         Get:
           Type: Api
           Properties:
-            Path: /queue/matches
+            Path: /v1/queue/matches
             Method: DELETE
             RestApiId: !Ref Api
       Policies:
@@ -179,7 +179,7 @@ Resources:
         Get:
           Type: Api
           Properties:
-            Path: /queue
+            Path: /v1/queue
             Method: DELETE
             RestApiId: !Ref Api
       Policies:
@@ -201,7 +201,7 @@ Resources:
         Put:
           Type: Api
           Properties:
-            Path: /data_mappers/{data_mapper_id}
+            Path: /v1/data_mappers/{data_mapper_id}
             Method: PUT
             RestApiId: !Ref Api
       Policies:
@@ -228,7 +228,7 @@ Resources:
         Get:
           Type: Api
           Properties:
-            Path: /data_mappers
+            Path: /v1/data_mappers
             Method: GET
             RestApiId: !Ref Api
       Policies:
@@ -243,7 +243,7 @@ Resources:
         Get:
           Type: Api
           Properties:
-            Path: /data_mappers/{data_mapper_id}
+            Path: /v1/data_mappers/{data_mapper_id}
             Method: DELETE
             RestApiId: !Ref Api
       Policies:
@@ -261,7 +261,7 @@ Resources:
         Get:
           Type: Api
           Properties:
-            Path: /jobs/{job_id}
+            Path: /v1/jobs/{job_id}
             Method: GET
             RestApiId: !Ref Api
       Policies:
@@ -277,7 +277,7 @@ Resources:
         List:
           Type: Api
           Properties:
-            Path: /jobs
+            Path: /v1/jobs
             Method: GET
             RestApiId: !Ref Api
       Policies:
@@ -293,7 +293,7 @@ Resources:
         List:
           Type: Api
           Properties:
-            Path: /jobs/{job_id}/events
+            Path: /v1/jobs/{job_id}/events
             Method: GET
             RestApiId: !Ref Api
       Policies:
@@ -310,7 +310,7 @@ Resources:
         List:
           Type: Api
           Properties:
-            Path: /settings
+            Path: /v1/settings
             Method: GET
             RestApiId: !Ref Api
       Policies:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -143,7 +143,7 @@ def api_client(cognito_token, stack):
             super(ApiGwSession, self).__init__()
 
         def request(self, method, url, data=None, params=None, headers=None, *args, **kwargs):
-            url = urljoin(self.base_url, url)
+            url = urljoin("{}/v1/".format(self.base_url), url)
             if isinstance(headers, dict):
                 self.default_headers.update(headers)
             return super(ApiGwSession, self).request(


### PR DESCRIPTION
By prepending a version in each endpoint, we should have extra flexibility in the future for when deploying breaking changes.

I investigated playing with the stage prefix "Prod" rather than appending in each endpoint, but I basically wanted to be sure I could deploy the API gateway with a v1/endpoint and v2/endpoint co-existing in the same deployment, and Stages don't actually allow that as you need to deploy an API with a specific Stage. A way is to deploy a complete different gateway but then the second would have a complete different URL and I think that would be a breaking change I wouldn't want too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
