### PR TITLE
Remove redundant policies

### DIFF
--- a/templates/web_ui.yaml
+++ b/templates/web_ui.yaml
@@ -41,24 +41,6 @@ Resources:
             Condition:
               Bool:
                 'aws:SecureTransport': 'false'
-          - Sid: DenyIncorrectEncryptionHeader
-            Action: s3:PutObject*
-            Effect: Deny
-            Resource: !Sub arn:aws:s3:::${WebUIBucket}/*
-            Principal: '*'
-            Condition:
-              StringNotEquals:
-                's3:x-amz-server-side-encryption':
-                  - AES256
-                  - aws:kms
-          - Sid: DenyUnEncryptedObjectUploads
-            Action: s3:PutObject*
-            Effect: Deny
-            Resource: !Sub arn:aws:s3:::${WebUIBucket}/*
-            Principal: '*'
-            Condition:
-              'Null':
-                's3:x-amz-server-side-encryption': true
           - !If
             - WithCloudFront
             - Sid: CloudFrontOriginOnly


### PR DESCRIPTION
These policies are actually unnecessary given we have standard encryption in the bucket and when that happens it's not possible to upload an unencrypted object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
