### PR TITLE
Introduce CloudFront secure headers [blocked - don't merge]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
     -   id: git-secrets
 -   repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v0.28.2
+    rev: v0.29.0
     hooks:
     -   id: cfn-python-lint
         args: [--ignore-templates=templates/api.definition.yml]

--- a/backend/lambdas/custom_resources/create_regional_edge_lambda.py
+++ b/backend/lambdas/custom_resources/create_regional_edge_lambda.py
@@ -1,0 +1,72 @@
+import boto3
+import uuid
+import zipfile
+from crhelper import CfnResource
+from decorators import with_logging
+
+
+helper = CfnResource(json_logging=False, log_level='DEBUG',
+                     boto_level='CRITICAL')
+
+lambda_code = """
+def handler(event, context):
+    response = event['Records'][0]['cf']['response']
+    h = response['headers']
+    h['strict-transport-security'] = [{ 'key': 'Strict-Transport-Security', 'value': 'max-age=63072000; includeSubdomains; preload'}]
+    h['content-security-policy'] = [{ 'key': 'Content-Security-Policy', 'value': "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"}]
+    h['x-content-type-options'] = [{ 'key': 'X-Content-Type-Options', 'value': 'nosniff'}]
+    h['x-frame-options'] = [{ 'key': 'X-Frame-Options', 'value': 'DENY'}]
+    h['x-xss-protection'] = [{ 'key': 'X-XSS-Protection', 'value': '1; mode=block'}]
+    h['referrer-policy'] = [{ 'key': 'Referrer-Policy', 'value': 'same-origin'}]
+    return response
+"""
+
+client = boto3.client("lambda", region_name='us-east-1')
+
+
+def zip_lambda_code():
+    lambda_code_path = "/tmp/lambda_code.zip"
+    with zipfile.ZipFile(lambda_code_path, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        info = zipfile.ZipInfo("append_headers.py")
+        info.external_attr = 0o777 << 16
+        zf.writestr(info, lambda_code)
+        zf.close()
+    return lambda_code_path
+
+
+@with_logging
+@helper.create
+@helper.update
+def create(event, context):
+    lambda_code_path = zip_lambda_code()
+    props = event.get('ResourceProperties', None)
+    lambda_role_arn = props.get("RoleArn")
+    resource_prefix = props.get("ResourcePrefix")
+    lambda_function_name = "{}-{}".format(resource_prefix, uuid.uuid4())
+    with open(lambda_code_path, 'rb') as zf:
+        response = client.create_function(
+            FunctionName=lambda_function_name,
+            Runtime='python3.7',
+            Role=lambda_role_arn,
+            Handler='append_headers.handler',
+            Code={'ZipFile': zf.read()},
+            Description='Lambda@Edge for the S3 Find and Forget Solution',
+            Timeout=5,
+            Publish=True
+        )
+
+        function_arn = response['FunctionArn']
+        with_version = "{}:{}".format(function_arn, response['Version'])
+        helper.Data.update({"FunctionArnWithVersion": with_version})
+
+        return function_arn
+
+
+@with_logging
+@helper.delete
+def delete(event, context):
+    return None
+
+
+def handler(event, context):
+    helper(event, context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest==5.3.5
-cfn-lint==0.28.2
+cfn-lint==0.29.0
 cfn-flip==1.2.2
 mock==4.0.1
 pytest-cov==2.8.1

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -282,6 +282,12 @@ Resources:
     Properties:
       TemplateURL: ./web_ui.yaml
       Parameters:
+        CommonLayers: !Join
+          - ","
+          - - !GetAtt LayersStack.Outputs.AWSSDKLayer
+            - !GetAtt LayersStack.Outputs.Decorators
+            - !GetAtt LayersStack.Outputs.BotoUtils
+            - !GetAtt LayersStack.Outputs.CustomResourceHelper
         CreateCloudFrontDistribution: !Ref CreateCloudFrontDistribution
         ResourcePrefix: !Ref ResourcePrefix
 

--- a/templates/web_ui.yaml
+++ b/templates/web_ui.yaml
@@ -1,9 +1,29 @@
 AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
 Description: Amazon S3 Find and Forget Web UI
 
+Globals:
+  Function:
+    Runtime: python3.7
+    Timeout: 3
+    Layers: !Ref CommonLayers
+
 Parameters:
+  CommonLayers:
+    Type: CommaDelimitedList
   CreateCloudFrontDistribution:
     Type: String
+  LogLevel:
+    Type: String
+    Default: INFO
+    AllowedValues:
+    - CRITICAL
+    - FATAL
+    - ERROR
+    - WARNING
+    - INFO
+    - DEBUG
+    - NOTSET
   ResourcePrefix:
     Type: String
 
@@ -83,9 +103,58 @@ Resources:
             Cookies:
               Forward: none
           ViewerProtocolPolicy: redirect-to-https
+          LambdaFunctionAssociations:
+            - EventType: origin-response
+              IncludeBody: false
+              LambdaFunctionARN: !GetAtt CreateRegionalEdgeLambda.FunctionArnWithVersion
         PriceClass: PriceClass_All
         ViewerCertificate:
           CloudFrontDefaultCertificate: true
+
+  CreateRegionalEdgeLambdaFunction:
+    Type: AWS::Serverless::Function
+    Condition: WithCloudFront
+    Properties:
+      Handler: create_regional_edge_lambda.handler
+      CodeUri: ../backend/lambdas/custom_resources/
+      Description: Custom Lambda resource for the Amazon S3 Find and Forget Cloudformation Stack
+      Policies:
+        - Statement:
+          - Effect: Allow
+            Action:
+              - lambda:CreateFunction
+              - lambda:DeleteFunction
+            Resource: !Sub arn:aws:lambda:us-east-1:${AWS::AccountId}:function:${ResourcePrefix}*
+          - Effect: Allow
+            Action: iam:PassRole
+            Resource: !GetAtt LambdaEdgeFunctionRole.Arn
+
+  CreateRegionalEdgeLambda:
+    Type: Custom::Setup
+    Condition: WithCloudFront
+    Properties:
+      ServiceToken: !GetAtt CreateRegionalEdgeLambdaFunction.Arn
+      LogLevel: !Ref LogLevel
+      RoleArn: !GetAtt LambdaEdgeFunctionRole.Arn
+      ResourcePrefix: !Ref ResourcePrefix
+
+  LambdaEdgeFunctionRole:
+    Type: AWS::IAM::Role
+    Condition: WithCloudFront
+    Properties:
+        Path: "/"
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Sid: AllowLambdaServiceToAssumeRole
+              Effect: Allow
+              Action: sts:AssumeRole
+              Principal:
+                Service: 
+                  - lambda.amazonaws.com
+                  - edgelambda.amazonaws.com
 
 Outputs:
   CloudFrontDistribution:


### PR DESCRIPTION
Opening this PR as incomplete (no tests and docs yet) because I wanted to show some progress and discuss some items. 

Before this approach I tried:
1) Setting headers just in S3: not possible because of the custom headers
2) Spiking Amplify Console: it's quite great but depends on a repo. Should create a codecommit repo and populate it via the build which is nasty

Another idea I didn't try was to spin API Gateway with CF backed release on top of S3?

Things I didn't like about this approach (which is still the simplest and doesn't require using new services):
1) It requires the L@E to be in us-east-1 which I need to do with a Custom Resource 🤦‍♂ 
2) Deletion is weird, when you delete the CloudFront trigger is ok, but when you delete the lambda it fails because it's auto replicated and CF trigger disassociation is apparently kind of async (even if it takes its own 20m as usual). According to the docs, it may take a couple of hours. So, we would need to add in the docs that deleting that lambda is manual after a couple of hours from the stack deletion 🤦‍♂ 🤕 

If we are ok, I can add tests and clean this up, or we can just close. 
Another thing, should we make this optional?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
