### PR TITLE
Propagate role ARN from data mapper to task

### DIFF
--- a/backend/lambdas/tasks/submit_query_results.py
+++ b/backend/lambdas/tasks/submit_query_results.py
@@ -25,11 +25,17 @@ def handler(event, context):
                             None)
 
     paths = [row["Data"][path_field_index]["VarCharValue"] for row in rows]
-    batch_sqs_msgs(queue, [{
-        "JobId": event["JobId"],
-        "Object": p,
-        "Columns": event["Columns"]
-    } for p in paths])
+    messages = []
+    for p in paths:
+        msg = {
+            "JobId": event["JobId"],
+            "Object": p,
+            "Columns": event["Columns"],
+            "RoleArn": event.get("RoleArn", None),
+        }
+        messages.append({k: v for k, v in msg.items() if v is not None})
+
+    batch_sqs_msgs(queue, messages)
 
     return paths
 

--- a/tests/unit/test_submit_query_results.py
+++ b/tests/unit/test_submit_query_results.py
@@ -88,3 +88,43 @@ def test_it_submits_results_to_be_batched(paginate_mock, batch_sqs_msgs_mock):
         {"JobId": "1234", "Columns": columns, "Object": "s3://mybucket/mykey1"},
         {"JobId": "1234", "Columns": columns, "Object": "s3://mybucket/mykey2"},
     ])
+
+
+@patch("backend.lambdas.tasks.submit_query_results.batch_sqs_msgs")
+@patch("backend.lambdas.tasks.submit_query_results.paginate")
+def test_it_propagates_role_arn(paginate_mock, batch_sqs_msgs_mock):
+    paginate_mock.return_value = iter([
+        {
+            "Data": [
+                {
+                    "VarCharValue": "$path"
+                },
+            ]
+        },
+        {
+            "Data": [
+                {
+                    "VarCharValue": "s3://mybucket/mykey1"
+                },
+            ]
+        },
+    ])
+    columns = [{
+      "Column": "customer_id",
+      "MatchIds": [
+        "2732559"
+      ]
+    }]
+
+    handler({
+        "RoleArn": "arn:aws:iam:accountid:role/rolename",
+        "JobId": "1234",
+        "QueryId": "123",
+        "Columns": columns
+    }, SimpleNamespace())
+    batch_sqs_msgs_mock.assert_called_with(ANY, [
+        {
+            "JobId": "1234", "Columns": columns,
+            "Object": "s3://mybucket/mykey1",
+            "RoleArn": "arn:aws:iam:accountid:role/rolename"},
+    ])


### PR DESCRIPTION
*Description of changes:*
Ensures that the RoleArn will be propagated to the Fargate task if it is present on the data mapper. Permissions for assuming the role and setting the Role ARN on the data mapper will be done separately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
