### PR TITLE
Prevent parameter to be empty

### DIFF
--- a/templates/role.yaml
+++ b/templates/role.yaml
@@ -5,9 +5,7 @@ Parameters:
   SourceAccountId:
     Type: String
     Description: The ID of the AWS account in which the S3F2 solution is deployed
-    MinLength: 12
-    MaxLength: 12
-
+    AllowedPattern: "^[0-9]{12}$"
 
 Resources:
   Role:


### PR DESCRIPTION
When empty, stack fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
