### PR TITLE
Show Task Id in logs

### DIFF
--- a/tests/unit/test_delete_files.py
+++ b/tests/unit/test_delete_files.py
@@ -349,24 +349,57 @@ def test_it_fetches_task_id_from_metadata_uri(url_open_mock):
     res.read.return_value = b'{"Labels": {"com.amazonaws.ecs.task-arn": "arn/task-id"}}\n'
     resp = get_emitter_id()
     assert "ECSTask_task-id" == resp
+    url_open_mock.assert_called_with("http://metadatauri/path", timeout=1)
 
 
 @patch("os.getenv", MagicMock(return_value="http://metadatauri/path"))
 @patch("urllib.request.urlopen")
-def test_it_deafaults_task_id_if_http_issue(url_open_mock):
+@patch("backend.ecs_tasks.delete_files.delete_files.logger")
+def test_it_defaults_task_id_if_urlerror(logger_mock, url_open_mock):
     get_emitter_id.cache_clear()
     res = MagicMock()
     url_open_mock.return_value = res
     res.read.side_effect = URLError("foo")
     resp = get_emitter_id()
     assert "ECSTask" == resp
+    logger_mock.warning.assert_called_with("Error when accessing the metadata service: foo")
+
+
+@patch("os.getenv", MagicMock(return_value="http://metadatauri/path"))
+@patch("urllib.request.urlopen")
+@patch("backend.ecs_tasks.delete_files.delete_files.logger")
+def test_it_defaults_task_id_if_malformed_response(logger_mock, url_open_mock):
+    get_emitter_id.cache_clear()
+    res = MagicMock()
+    url_open_mock.return_value = res
+    res.read.return_value = b'{}\n'
+    resp = get_emitter_id()
+    assert "ECSTask" == resp
+    logger_mock.warning.assert_called_with("Malformed response from the metadata service: b'{}\\n'")
+
+
+@patch("os.getenv", MagicMock(return_value="http://metadatauri/path"))
+@patch("urllib.request.urlopen")
+@patch("backend.ecs_tasks.delete_files.delete_files.logger")
+def test_it_defaults_task_id_if_generic_error(logger_mock, url_open_mock):
+    get_emitter_id.cache_clear()
+    res = MagicMock()
+    url_open_mock.return_value = res
+    res.read.side_effect = NameError("error")
+    resp = get_emitter_id()
+    assert "ECSTask" == resp
+    logger_mock.warning.assert_called_with("Error when getting emitter id from metadata service: error")
 
 
 @patch("os.getenv", MagicMock(return_value=None))
-def test_it_provides_default_id():
+@patch("urllib.request.urlopen")
+@patch("backend.ecs_tasks.delete_files.delete_files.logger")
+def test_it_defaults_task_id_if_env_variable_not_set(logger_mock, url_open_mock):
     get_emitter_id.cache_clear()
     resp = get_emitter_id()
     assert "ECSTask" == resp
+    logger_mock.warning.assert_not_called()
+    url_open_mock.assert_not_called()
 
 
 @patch.dict(os.environ, {'JobTable': 'test'})


### PR DESCRIPTION
When using Fargate, we need to use the metadata uri to fetch the information.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
