### PR TITLE
Use account token instead of actions token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/create-release@latest
         if: env.THIS_VERSION > env.LATEST
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
           tag_name: v${{ env.THIS_VERSION }}
           release_name: Release v${{ env.THIS_VERSION }}


### PR DESCRIPTION
I deleted 0.1 so after merge we can test if this actually correctly triggers the publish.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
