### PR TITLE
Limit event triggers

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@
 name: Publish Version
 on:
   release:
-    types: [created, published, prereleased, edited]
+    types: [created, edited]
 jobs:
   publish:
     name: Publish Version


### PR DESCRIPTION
This to make sure that after successful release we have only 1 trigger rather than 3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
