### PR TITLE
Handle SF start failure

### DIFF
--- a/backend/lambdas/jobs/stream_processor.py
+++ b/backend/lambdas/jobs/stream_processor.py
@@ -67,7 +67,8 @@ def process_job(job):
         logger.warning("Execution %s already exists", job_id)
     except (ClientError, ValueError) as e:
         emit_event(job_id, "Exception", {
-            "Error": "Unable to start StepFunction execution: {}".format(str(e))
+            "Error": "ExecutionFailure",
+            "Cause": "Unable to start StepFunction execution: {}".format(str(e))
         }, "StreamProcessor")
 
 

--- a/tests/unit/jobs/test_stream_processor.py
+++ b/tests/unit/jobs/test_stream_processor.py
@@ -206,7 +206,8 @@ def test_it_handles_execution_failure(mock_emit, mock_client):
         "CreatedAt": 123.0,
     })
     mock_emit.assert_called_with("job123", "Exception", {
-        "Error": "Unable to start StepFunction execution: An error occurred (Unknown) when calling the start_execution operation: Unknown"
+        "Error": "ExecutionFailure",
+        "Cause": "Unable to start StepFunction execution: An error occurred (Unknown) when calling the start_execution operation: Unknown"
     }, "StreamProcessor")
 
 @patch("backend.lambdas.jobs.stream_processor.process_job", Mock(return_value=None))


### PR DESCRIPTION
Currently, when the SF fails to start (for instance, if the queue is too large) the job stays on the `QUEUED` state basically blocking the system.
In this way the exception is visible as event and the job moves to `FAILED`.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
