### PR TITLE
Add acceptance error tests

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -469,6 +469,7 @@ def dummy_lake(s3_resource, stack, data_access_role):
     yield {
         "bucket_name": bucket_name,
         "bucket": bucket,
+        "policy": policy
     }
 
     # Cleanup

--- a/tests/acceptance/test_job.py
+++ b/tests/acceptance/test_job.py
@@ -223,8 +223,8 @@ def test_it_deletes_old_versions(del_queue_factory, job_factory, dummy_lake, glu
     assert 1 == len(list(bucket.object_versions.filter(Prefix=object_key)))
 
 
-def test_it_handles_find_failed(del_queue_factory, job_factory, dummy_lake, glue_data_mapper_factory, data_loader,
-                                job_finished_waiter, job_table, policy_changer, stack):
+def test_it_handles_find_permission_issues(del_queue_factory, job_factory, dummy_lake, glue_data_mapper_factory,
+                                           data_loader, job_finished_waiter, job_table, policy_changer, stack):
     # Arrange
     glue_data_mapper_factory("test", partition_keys=["year", "month", "day"], partitions=[["2019", "08", "20"]])
     item = del_queue_factory("12345")
@@ -253,6 +253,36 @@ def test_it_handles_find_failed(del_queue_factory, job_factory, dummy_lake, glue
     job_finished_waiter.wait(TableName=job_table.name, Key={"Id": {"S": job_id}, "Sk": {"S": job_id}})
     # Assert
     assert "FIND_FAILED" == job_table.get_item(Key={"Id": job_id, "Sk": job_id})["Item"]["JobStatus"]
+    assert 1 == len(list(bucket.object_versions.filter(Prefix=object_key)))
+
+
+def test_it_handles_forget_permission_issues(del_queue_factory, job_factory, dummy_lake, glue_data_mapper_factory,
+                                             data_loader, job_finished_waiter, job_table, policy_changer, stack):
+    # Arrange
+    glue_data_mapper_factory("test", partition_keys=["year", "month", "day"], partitions=[["2019", "08", "20"]])
+    item = del_queue_factory("12345")
+    object_key = "test/2019/08/20/test.parquet"
+    data_loader("basic.parquet", object_key)
+    bucket = dummy_lake["bucket"]
+    bucket_name = dummy_lake["bucket_name"]
+    policy = json.loads(dummy_lake["policy"].policy)
+    policy["Statement"].append({
+        "Effect": "Deny",
+        "Principal": {
+            "AWS": [stack["DeleteTaskRoleArn"]]
+        },
+        "Action": "s3:*",
+        "Resource": [
+            "arn:aws:s3:::{}".format(bucket_name),
+            "arn:aws:s3:::{}/*".format(bucket_name),
+        ]
+    })
+    policy_changer(policy)
+    job_id = job_factory(del_queue_items=[item])["Id"]
+    # Act
+    job_finished_waiter.wait(TableName=job_table.name, Key={"Id": {"S": job_id}, "Sk": {"S": job_id}})
+    # Assert
+    assert "FORGET_PARTIALLY_FAILED" == job_table.get_item(Key={"Id": job_id, "Sk": job_id})["Item"]["JobStatus"]
     assert 1 == len(list(bucket.object_versions.filter(Prefix=object_key)))
 
 


### PR DESCRIPTION
*Description of changes:*
Adds acceptance tests for:
- Athena unable to access data lake
- Fargate unable to access data lake
- Invalid Role ARN supplied for data mapper

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
