### PR TITLE
Defer admin user creation till nested stacks complete

### DIFF
--- a/templates/auth.yaml
+++ b/templates/auth.yaml
@@ -3,8 +3,6 @@ Transform: AWS::Serverless-2016-10-31
 Description: Amazon S3 Find and Forget Auth Infrastructure
 
 Parameters:
-  AdminEmail:
-    Type: String
   CognitoAdvancedSecurity:
     Type: String
   ResourcePrefix:
@@ -56,19 +54,6 @@ Resources:
       GenerateSecret: false
       RefreshTokenValidity: 30
       PreventUserExistenceErrors: ENABLED
-
-  CognitoUserPoolUser:
-    Type: AWS::Cognito::UserPoolUser
-    Properties:
-      Username: !Ref AdminEmail
-      UserPoolId: !Ref CognitoUserPool
-      DesiredDeliveryMediums:
-        - EMAIL
-      UserAttributes:
-        - Name: email
-          Value: !Ref AdminEmail
-        - Name: email_verified
-          Value: "true"
 
   ServiceInvokeRole:
     Type: AWS::IAM::Role

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -167,6 +167,28 @@ Resources:
         }
       Description: SSM Parameter for S3F2 configuration.
 
+  CognitoUserPoolUser:
+    Type: AWS::Cognito::UserPoolUser
+    DependsOn:
+      - APIStack
+      - DDBStack
+      - DelStack
+      - DeployStack
+      - LayersStack
+      - StateMachineStack
+      - StreamProcessorStack
+      - WebUIStack
+    Properties:
+      Username: !Ref AdminEmail
+      UserPoolId: !GetAtt AuthStack.Outputs.CognitoUserPoolId
+      DesiredDeliveryMediums:
+        - EMAIL
+      UserAttributes:
+        - Name: email
+          Value: !Ref AdminEmail
+        - Name: email_verified
+          Value: "true"
+
   APIStack:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -191,7 +213,6 @@ Resources:
     Properties:
       TemplateURL: ./auth.yaml
       Parameters:
-        AdminEmail: !Ref AdminEmail
         CognitoAdvancedSecurity: !Ref CognitoAdvancedSecurity
         ResourcePrefix: !Ref ResourcePrefix
   DDBStack:


### PR DESCRIPTION
*Description of changes:*
- Defers admin user creation till nested stacks are successfully created
- If updating an existing stack, you must temporarily change the `AdminEmail` stack parameter whilst deploying this update. The value can be reverted after this update is deployed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
