### PR TITLE
Fix package name for pretter-eslint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,13 @@ format-cfn:
 
 .PHONY: format-docs
 format-docs:
-	npx prettier-eslint ./*.md ./docs/*.md --write --prose-wrap always
+	npx prettier-eslint-cli ./*.md ./docs/*.md --write --prose-wrap always
 	git add *.md
 	git add docs/*.md
 
 .PHONY: format-js
 format-js:
-	npx prettier-eslint $(PWD)/frontend/src/**/*.js --write --prose-wrap always
+	npx prettier-eslint-cli $(PWD)/frontend/src/**/*.js --write --prose-wrap always
 	git add frontend/src/
 
 generate-api-docs:


### PR DESCRIPTION
*Description of changes:*

The CLI used here is actually contained in the prettier-eslint-cli npm
package. This change fixes an issue where these targets could error that
the 'prettier-eslint' command could not be found.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
