### PR TITLE
Paginate over scan without sorting guarantees

### DIFF
--- a/backend/lambdas/queue/schemas/list_queue_items.json
+++ b/backend/lambdas/queue/schemas/list_queue_items.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "List Queue Items Handler",
+    "type": "object",
+    "properties": {
+        "queryStringParameters": {
+            "description": "Query string parameters for the request",
+            "type": [ "object", "null" ],
+            "properties": {
+                "start_at": {
+                    "description": "Starting watermark",
+                    "type": "string"
+                },
+                "page_size": {
+                    "description": "Maximum page size",
+                    "type": "string",
+                    "pattern": "^([1-9][0-9]{0,2}|1000)$"
+                }
+            }
+        }
+    }
+}

--- a/docs/api/Apis/DeletionQueueApi.md
+++ b/docs/api/Apis/DeletionQueueApi.md
@@ -64,7 +64,11 @@ null (empty response body)
 Lists deletion queue items
 
 ### Parameters
-This endpoint does not need any parameters.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **StartAt** | **String**| Start at watermark query string parameter | [optional] [default to 0]
+ **PageSize** | **Integer**| Page size query string parameter. Min: 1. Max: 1000 | [optional] [default to null]
 
 ### Return type
 

--- a/docs/api/Models/DeletionQueue.md
+++ b/docs/api/Models/DeletionQueue.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MatchIds** | [**List**](DeletionQueueItem.md) | The list of Match IDs currently in the queue | [optional] [default to null]
+**NextStart** | [**String**](string.md) | The watermark to use when requesting the next page of results | [optional] [default to ]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/frontend/src/components/pages/DeletionQueue.js
+++ b/frontend/src/components/pages/DeletionQueue.js
@@ -3,12 +3,20 @@ import { Button, Col, Form, Modal, Row, Spinner, Table } from "react-bootstrap";
 
 import Alert from "../Alert";
 import Icon from "../Icon";
+import TablePagination from "../TablePagination";
 
 import {
-    formatErrorMessage, isEmpty, isUndefined, sortBy, formatDateTime
+  formatErrorMessage,
+  isEmpty,
+  isUndefined,
+  sortBy,
+  formatDateTime
 } from "../../utils";
 
+const PAGE_SIZE = 10;
+
 export default ({ gateway, onPageChange }) => {
+  const [currentPage, setCurrentPage] = useState(0);
   const [deleting, setDeleting] = useState(false);
   const [errorDetails, setErrorDetails] = useState(undefined);
   const [formState, setFormState] = useState("initial");
@@ -17,6 +25,7 @@ export default ({ gateway, onPageChange }) => {
   const [selectedRow, selectRow] = useState(undefined);
 
   const noSelected = isUndefined(selectedRow);
+  const pages = Math.ceil(queue.length / PAGE_SIZE);
 
   const refreshQueue = () => {
     selectRow(undefined);
@@ -29,10 +38,12 @@ export default ({ gateway, onPageChange }) => {
     setDeleting(false);
     setFormState("initial");
     try {
-      await gateway.deleteQueueMatches([{
-        MatchId: queue[selectedRow].MatchId,
-        CreatedAt: queue[selectedRow].CreatedAt,
-      }]);
+      await gateway.deleteQueueMatches([
+        {
+          MatchId: queue[selectedRow].MatchId,
+          CreatedAt: queue[selectedRow].CreatedAt
+        }
+      ]);
       refreshQueue();
     } catch (e) {
       setFormState("error");
@@ -53,6 +64,9 @@ export default ({ gateway, onPageChange }) => {
     };
     fetchQueue();
   }, [gateway, renderTableCount]);
+
+  const shouldShowItem = index =>
+    index >= PAGE_SIZE * currentPage && index < PAGE_SIZE * (currentPage + 1);
 
   return (
     <div className="page-table">
@@ -79,13 +93,18 @@ export default ({ gateway, onPageChange }) => {
           </Button>
         </Col>
       </Row>
-
+      <Row className="pagination">
+        <Col></Col>
+        <Col className="buttons-right" md="auto">
+          <TablePagination onPageChange={setCurrentPage} pages={pages} />
+        </Col>
+      </Row>
       {formState === "initial" && (
         <Spinner animation="border" role="status" className="spinner" />
       )}
       {formState === "error" && (
-        <Alert type="error" title={errorDetails}>
-          Please retry later.
+        <Alert type="error" title="An error happened">
+          {errorDetails}
         </Alert>
       )}
       {!noSelected && (
@@ -129,25 +148,28 @@ export default ({ gateway, onPageChange }) => {
           </thead>
           <tbody>
             {queue &&
-              queue.map((queueMatch, index) => (
-                <tr
-                  key={index}
-                  className={selectedRow === index ? "selected" : undefined}
-                >
-                  <td style={{ textAlign: "center" }}>
-                    <Form.Check
-                      inline
-                      type="radio"
-                      id={`inline-${index}`}
-                      name="item"
-                      onClick={() => selectRow(index)}
-                    />
-                  </td>
-                  <td>{queueMatch.MatchId}</td>
-                  <td>{formatDateTime(queueMatch.CreatedAt)}</td>
-                  <td>{queueMatch.DataMappers.join(", ") || "*"}</td>
-                </tr>
-              ))}
+              queue.map(
+                (queueMatch, index) =>
+                  shouldShowItem(index) && (
+                    <tr
+                      key={index}
+                      className={selectedRow === index ? "selected" : undefined}
+                    >
+                      <td style={{ textAlign: "center" }}>
+                        <Form.Check
+                          inline
+                          type="radio"
+                          id={`inline-${index}`}
+                          name="item"
+                          onClick={() => selectRow(index)}
+                        />
+                      </td>
+                      <td>{queueMatch.MatchId}</td>
+                      <td>{formatDateTime(queueMatch.CreatedAt)}</td>
+                      <td>{queueMatch.DataMappers.join(", ") || "*"}</td>
+                    </tr>
+                  )
+              )}
           </tbody>
         </Table>
         {isEmpty(queue) && formState !== "initial" && (

--- a/frontend/src/utils/gateway.js
+++ b/frontend/src/utils/gateway.js
@@ -1,5 +1,21 @@
 import { apiGateway, glueGateway, stsGateway } from "./request";
 
+const getPaginatedList = async (endpoint, key, pageSize) => {
+  const all = [];
+  let watermark = undefined;
+
+  while (true) {
+    let qs = `?page_size=${pageSize || 10}`;
+    if (watermark) qs += `&start_at=${watermark}`;
+    const page = await apiGateway(`${endpoint}${qs}`);
+    all.push(...page[key]);
+
+    if (page.NextStart) watermark = encodeURIComponent(page.NextStart);
+    else break;
+  }
+  return all;
+};
+
 export default {
   deleteDataMapper(id) {
     return apiGateway(`data_mappers/${id}`, { method: "del" });
@@ -75,18 +91,7 @@ export default {
   },
 
   async getJobs() {
-    const allJobs = [];
-    let watermark = undefined;
-
-    while (true) {
-      const qs = watermark ? `?start_at=${watermark}` : "";
-      const page = await apiGateway(`jobs${qs}`);
-      allJobs.push(...page.Jobs);
-
-      if (page.NextStart) watermark = page.NextStart;
-      else break;
-    }
-    return { Jobs: allJobs };
+    return { Jobs: await getPaginatedList("jobs", "Jobs") };
   },
 
   async getJobEvents(
@@ -123,8 +128,8 @@ export default {
     return data;
   },
 
-  getQueue() {
-    return apiGateway("queue");
+  async getQueue() {
+    return { MatchIds: await getPaginatedList("queue", "MatchIds", 500) };
   },
 
   getSettings() {

--- a/templates/api.definition.yml
+++ b/templates/api.definition.yml
@@ -25,6 +25,9 @@ paths:
       operationId: "listDeletionQueueMatches"
       security:
         - CognitoAuthorizer: []
+      parameters:
+        - '$ref': '#/components/parameters/StartAtQS'
+        - '$ref': '#/components/parameters/PageSizeQS'
       responses:
         '200':
           description: OK
@@ -39,6 +42,11 @@ paths:
                     description: "The list of Match IDs currently in the queue"
                     items:
                       $ref: '#/components/schemas/DeletionQueueItem'
+                  NextStart:
+                    type: "string"
+                    nullable: true
+                    default: ""
+                    description: "The watermark to use when requesting the next page of results"
       x-amazon-apigateway-integration:
         uri:
           Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetDeletionQueue.Arn}/invocations"


### PR DESCRIPTION
Here I'm solving the same issue as #135 but with a different approach.
By not guaranteeing sorting orders (which I don't think we need for the queue API) we can just iterate over a paginated scan. This allows great scalability and good simplicity as it doesn't need to alter anything on the Dynamo Table Schema.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
