### PR TITLE
Consistently show errors

### DIFF
--- a/frontend/src/components/StartDeletionJob.js
+++ b/frontend/src/components/StartDeletionJob.js
@@ -87,7 +87,7 @@ export default ({ className, gateway, goToJobDetails }) => {
             <Spinner animation="border" role="status" className="spinner" />
           )}
           {formState === "error" && (
-            <Alert type="error" title="An error happened">
+            <Alert type="error" title="An Error Occurred">
               {errorDetails}
             </Alert>
           )}

--- a/frontend/src/components/pages/DataMappers.js
+++ b/frontend/src/components/pages/DataMappers.js
@@ -118,7 +118,7 @@ export default ({ gateway, onPageChange }) => {
         <Spinner animation="border" role="status" className="spinner" />
       )}
       {formState === "error" && (
-        <Alert type="error" title="An error happened">
+        <Alert type="error" title="An Error Occurred">
           {errorDetails}
         </Alert>
       )}

--- a/frontend/src/components/pages/DeletionJob.js
+++ b/frontend/src/components/pages/DeletionJob.js
@@ -190,7 +190,7 @@ export default ({ gateway, jobId }) => {
           <Spinner animation="border" role="status" className="spinner" />
         )}
         {formState === "error" && (
-          <Alert type="error" title="An error happened">
+          <Alert type="error" title="An Error Occurred">
             {errorDetails}
           </Alert>
         )}
@@ -294,7 +294,7 @@ export default ({ gateway, jobId }) => {
         )}
       </div>
       {eventsState === "error" && (
-        <Alert type="error" title="Unable to load Events">
+        <Alert type="error" title="Unable to Load Events">
           {eventsErrorDetails}
         </Alert>
       )}

--- a/frontend/src/components/pages/DeletionJobs.js
+++ b/frontend/src/components/pages/DeletionJobs.js
@@ -71,7 +71,7 @@ export default ({ gateway, goToJobDetails }) => {
         <Spinner animation="border" role="status" className="spinner" />
       )}
       {formState === "error" && (
-        <Alert type="error" title="An error happened">
+        <Alert type="error" title="An Error Occurred">
           {errorDetails}
         </Alert>
       )}


### PR DESCRIPTION
Just found that when the error is multi-line and set as title, the display is broken in the `<Alert>` component. In this way the system-generated text is also shown correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
