### PR TITLE
Fix SignIn components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -170,19 +170,19 @@
       "integrity": "sha512-OLdZmUCVK29+JV8PrkgVPjg+GIFtBnNjhC0JSRgrps+ynOFkibMQQPKeFXlTYtlukuCuepCelPSkjxvhcLq2ZA=="
     },
     "@aws-amplify/ui-components": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-0.4.0.tgz",
-      "integrity": "sha512-CyF5ryUiROQExdrYIK1lj8mL2eEu6NAWFyGhT+l3yjGHKD3jXbW/OrAfbBg0tY+MZS3guPWXLerMAiFoHnvR1Q==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-0.4.1.tgz",
+      "integrity": "sha512-WJFQQ+z13s0HsqxOTapIGfTBn53MCGv2oY1+3McOxPQo5et3Ma99bSC8dvqmP0Ksgpgc7DGdxPUtI+q5UtQIvA==",
       "requires": {
         "qrcode": "^1.4.4"
       }
     },
     "@aws-amplify/ui-react": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-0.2.5.tgz",
-      "integrity": "sha512-+RgjkWJFq13ZIZ/7Ia30h/99hsJDfstWT57kMHHXuPVIXtz3HS185GTN/WXIaUEIpRpij62NaQyVfge6LU1Wjg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-0.2.6.tgz",
+      "integrity": "sha512-YL1UTz+N9f32s0GL2aaRija1GHUDUcbfGpRwwetekmRtsYYMg6CMAs/QZ2TTq94HkJQwpxihim54FUmLjO6Rrw==",
       "requires": {
-        "@aws-amplify/ui-components": "^0.4.0"
+        "@aws-amplify/ui-components": "^0.4.1"
       }
     },
     "@aws-amplify/xr": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/awslabs/amazon-s3-find-and-forget"
   },
   "dependencies": {
-    "@aws-amplify/ui-react": "^0.2.5",
+    "@aws-amplify/ui-components": "^0.4.1",
+    "@aws-amplify/ui-react": "^0.2.6",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { AmplifyAuthenticator, AmplifySignIn } from "@aws-amplify/ui-react";
-
+import { onAuthUIStateChange } from "@aws-amplify/ui-components";
 import AppLayout from "./components/AppLayout";
 import Header from "./components/Header";
 import {
@@ -22,8 +22,6 @@ import {
   NewDeletionQueueMatchPage,
 } from "./components/pages";
 import gateway from "./utils/gateway";
-import { isUndefined } from "./utils";
-import { Auth } from "aws-amplify";
 
 export default () => {
   const [authState, setAuthState] = useState(undefined);
@@ -103,20 +101,8 @@ export default () => {
   ];
 
   useEffect(() => {
-    if (isUndefined(authState)) {
-      // We want to establish if authState is undefined because the user is not authenticated
-      // or because the state hasn't been updated yet by the authenticator. This is important
-      // because the <AmplifyAuthenticator> doesn't show if the user is already authenticated,
-      // which is a scenario that can happen if the user closes the page and we want to persist
-      // its session.
-      Auth.currentAuthenticatedUser()
-        .then(() => setAuthState("signedin"))
-        .catch(() => {
-          // The user appears unauthenticated. All fine. The <AmplifyAuthenticator> will be
-          // rendered correctly.
-        });
-    }
-  }, [authState]);
+    return onAuthUIStateChange((s) => setAuthState(s));
+  }, []);
 
   const signedIn = authState === "signedin";
   return (
@@ -134,7 +120,6 @@ export default () => {
             <AmplifySignIn
               slot="sign-in"
               usernameAlias="email"
-              handleAuthStateChange={(s) => setAuthState(s)}
               formFields={[
                 {
                   type: "email",


### PR DESCRIPTION
There is a bug affecting the new react sign in components. Authenticator is designed to be context sensitive and render a series of components depending on the current behaviour. When a new user is created and the first login is attempted, for instance, the Authenticator nests a new component for the password reset, and so on. Unfortunately by setting `handleAuthStateChange` we override the current behaviour and the Authenticator has no clue that something needs to change. So, when the authState transitions from `undefined` to `newpasswordreset` the Sign in just stays there and nothing happens.

By reading up on this issue: https://github.com/aws-amplify/amplify-js/issues/5825 I found there is a solution that actually is more elegant, as it allows to watch the whole Authenticator state from the outside (so that we can render or not the full page) but also not being in need to override the `handleAuthStateChange` (so that the Authenticator can handle its own state internally and render all the nested components with no errors).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
