### PR TITLE
Pyarrow schema bugfix

### DIFF
--- a/backend/ecs_tasks/delete_files/parquet.py
+++ b/backend/ecs_tasks/delete_files/parquet.py
@@ -38,7 +38,7 @@ def delete_matches_from_file(parquet_file, to_delete):
                 current_rows = get_row_count(df)
                 df = delete_from_dataframe(df, to_delete)
                 new_rows = get_row_count(df)
-                tab = pa.Table.from_pandas(df, preserve_index=False).replace_schema_metadata()
+                tab = pa.Table.from_pandas(df, schema=schema, preserve_index=False).replace_schema_metadata()
                 writer.write_table(tab)
                 stats.update({"DeletedRows": current_rows - new_rows})
         return out_stream, stats

--- a/backend/ecs_tasks/delete_files/requirements.in
+++ b/backend/ecs_tasks/delete_files/requirements.in
@@ -1,4 +1,4 @@
-pyarrow==0.16.0
+pyarrow==0.17.1
 s3fs==0.4.0
 python-snappy==0.5.4
 pandas==1.0.1

--- a/backend/ecs_tasks/delete_files/requirements.txt
+++ b/backend/ecs_tasks/delete_files/requirements.txt
@@ -11,11 +11,11 @@ fsspec==0.7.2             # via s3fs
 jmespath==0.9.5           # via boto3, botocore
 numpy==1.18.2             # via pandas, pyarrow
 pandas==1.0.1             # via -r backend/ecs_tasks/delete_files/requirements.in
-pyarrow==0.16.0           # via -r backend/ecs_tasks/delete_files/requirements.in
+pyarrow==0.17.1           # via -r backend/ecs_tasks/delete_files/requirements.in
 python-dateutil==2.8.1    # via botocore, pandas
 python-snappy==0.5.4      # via -r backend/ecs_tasks/delete_files/requirements.in
 pytz==2019.3              # via pandas
 s3fs==0.4.0               # via -r backend/ecs_tasks/delete_files/requirements.in
 s3transfer==0.3.3         # via boto3
-six==1.14.0               # via pyarrow, python-dateutil
+six==1.14.0               # via python-dateutil
 urllib3==1.25.8           # via botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ pip-tools==5.1.2          # via -r requirements.in
 pluggy==0.13.1            # via pytest
 pre-commit==2.1.1         # via -r requirements.in
 py==1.8.1                 # via pytest
-pyarrow==0.16.0           # via -r ./backend/ecs_tasks/delete_files/requirements.txt
+pyarrow==0.17.1           # via -r ./backend/ecs_tasks/delete_files/requirements.txt
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via -r ./backend/lambda_layers/decorators/requirements.txt, jsonschema
 pytest-cov==2.8.1         # via -r requirements.in
@@ -53,7 +53,7 @@ pyyaml==5.3.1             # via cfn-flip, cfn-lint, pre-commit
 requests==2.23.0          # via -r ./backend/lambda_layers/cr_helper/requirements.txt, crhelper
 s3fs==0.4.0               # via -r ./backend/ecs_tasks/delete_files/requirements.txt
 s3transfer==0.3.3         # via -r ./backend/ecs_tasks/delete_files/requirements.txt, -r ./backend/lambda_layers/aws_sdk/requirements.txt, boto3
-six==1.14.0               # via -r ./backend/ecs_tasks/delete_files/requirements.txt, -r ./backend/lambda_layers/aws_sdk/requirements.txt, -r ./backend/lambda_layers/decorators/requirements.txt, aws-sam-translator, cfn-flip, cfn-lint, jsonschema, junit-xml, packaging, pip-tools, pyarrow, pyrsistent, python-dateutil, virtualenv
+six==1.14.0               # via -r ./backend/ecs_tasks/delete_files/requirements.txt, -r ./backend/lambda_layers/aws_sdk/requirements.txt, -r ./backend/lambda_layers/decorators/requirements.txt, aws-sam-translator, cfn-flip, cfn-lint, jsonschema, junit-xml, packaging, pip-tools, pyrsistent, python-dateutil, virtualenv
 toml==0.10.0              # via pre-commit
 urllib3==1.25.8           # via -r ./backend/ecs_tasks/delete_files/requirements.txt, -r ./backend/lambda_layers/aws_sdk/requirements.txt, -r ./backend/lambda_layers/cr_helper/requirements.txt, botocore, requests
 virtualenv==20.0.16       # via pre-commit

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.1)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.2)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -117,7 +117,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.1'
+      Version: 'v0.2'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*
By testing the solution with https://github.com/awslabs/game-analytics-pipeline I bumped into an interesting bug.
The ParquetWriter was failing to write a table because between the arrow=>pandas=>arrow conversions, a nullable string was not correctly passed through and set as null instead. That was causing the writer to fail:
```
Unprocessable message: Table schema does not match schema used to create file: 
table:
event_id: string
event_type: string
event_name: string
event_version: string
event_timestamp: int64
client_id: string
user_id: string
session_id: string
application_id: string
application_name: string
event_data: string
metadata: string
custom_event: null vs. 
file:
event_id: string
event_type: string
event_name: string
event_version: string
event_timestamp: int64
client_id: string
user_id: string
session_id: string
application_id: string
application_name: string
event_data: string
metadata: string
custom_event: string
```
After digging into the data, I observed that custom_event was always a null string, so when moving to pandas that was converted to a generic null, and when converting back there was a mismatch between types.

To fix, I found that it is possible to use the original schema rather then inferring the one from Pandas: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.from_pandas

After making this change, I was able to test the sample dataset and see that the conversion issue was gone.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
