### PR TITLE
Wait for codepipeline during upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.3
+
+### Summary
+
+- [#164](https://github.com/awslabs/amazon-s3-find-and-forget/pull/164): Fix for
+  a bug affecting v0.2 deployment via CloudFormation
+
 ## v0.2
 
 ### Summary

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -431,3 +431,4 @@ Resources:
       CodeBuildArtefactBucket: !Ref CodeBuildArtefactBucket
       ECRRepository: !Ref ECRRepository
       LogLevel: !Ref LogLevel
+      Version: !Ref Version

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.2)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.3)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -117,7 +117,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.2'
+      Version: 'v0.3'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*
During 0.2 upgrade, I noticed that the copy artifact was correctly performed but the deployment helper didn't wait for the codepipeline to be completed. This should fix (there is already a dependency between custom resources)

*PR Checklist:*

- [x] Changelog updated
- [x] Pre-commit checks pass
- [x] If releasing a new version, have you bumped the version int he main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
