### PR TITLE
5xx error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.4
+
+### Summary
+
+- [#171](https://github.com/awslabs/amazon-s3-find-and-forget/pull/171): Fix for
+  a bug affecting the API for 5xx responses not returning the appropriate CORS
+  headers
+
 ## v0.3
 
 ### Summary

--- a/templates/api.yaml
+++ b/templates/api.yaml
@@ -133,6 +133,17 @@ Resources:
                 - DefaultAccessControlOrigin
                 - !Sub "'${WebUIOrigin}'"
                 - !Sub "'${AccessControlAllowOriginOverride}'"
+        DEFAULT_5XX:
+          ResponseTemplates:
+            "application/json": '{ "Message": $context.error.messageString }'
+          ResponseParameters:
+            Headers:
+              Access-Control-Allow-Methods: "'*'"
+              Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+              Access-Control-Allow-Origin: !If
+                - DefaultAccessControlOrigin
+                - !Sub "'${WebUIOrigin}'"
+                - !Sub "'${AccessControlAllowOriginOverride}'"
 
   ## Queue
   EnqueueDeletion:

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.3)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.4)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -117,7 +117,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.3'
+      Version: 'v0.4'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*
I mistakenly deployed the solution from local source without properly installing the python dependencies and managed to generate some 5xx on the server. 
Unfortunately, when that happened, the frontend couldn't show any error because the CORS headers weren't being sent for 5xx codes. I think that the SAM usually takes care of that for you but if you override with `GatewayResponses` as we do, you then need to make that a comprehensive list for all the codes that need the CORS headers.

I managed to deploy this change and currently see the code showed in the frontend.
I thought about making it as acceptance, but I think it's probably not needed and I would need to change the code to make it happen, which I think it's not worth.

*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] If releasing a new version, have you bumped the version int he main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
