### PR TITLE
Convert directory targets to sentinel file targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ backend/lambda_layers/decorators/python
 build.zip
 packaged.zip
 frontend/public/settings.js
+*.sentinel
 
 # docs
 .openapi-generator/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.5
+
+### Summary
+
+- [#172](https://github.com/awslabs/amazon-s3-find-and-forget/pull/172): Fix for
+  an issue where Make may not install the required Lambda layer dependencies,
+  resulting in unusable builds.
+
 ## v0.4
 
 ### Summary

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.4)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.5)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -117,7 +117,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.4'
+      Version: 'v0.5'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*

This change intends to improve reliability of the build process. Whilst
having directory targets is semantically nice, it has resulted in a few
occassions where the characteristics of mtimes on directories has
resulted in targets not being built when they should be.


*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version int he main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
