### PR TITLE
Fix Sanitiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - [185](https://github.com/awslabs/amazon-s3-find-and-forget/pull/185): Fix dead
   links to VPC info in docs
+- [186](https://github.com/awslabs/amazon-s3-find-and-forget/pull/186): Fix
+  forget task log sanitiser to handle integer match IDs
 
 ## v0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - [185](https://github.com/awslabs/amazon-s3-find-and-forget/pull/185): Fix dead
   links to VPC info in docs
-- [186](https://github.com/awslabs/amazon-s3-find-and-forget/pull/186): Fix
-  forget task log sanitiser to handle integer match IDs
+- [186](https://github.com/awslabs/amazon-s3-find-and-forget/pull/186): Fix:
+  Solves an issue where the forget phase container could crash when redacting numeric Match IDs from its logs
 
 ## v0.7
 

--- a/backend/ecs_tasks/delete_files/events.py
+++ b/backend/ecs_tasks/delete_files/events.py
@@ -48,7 +48,7 @@ def sanitize_message(err_message, message_body):
             if isinstance(match_ids, Iterable):
                 matches.extend(match_ids)
         for m in matches:
-            sanitised = sanitised.replace(m, "*** MATCH ID ***")
+            sanitised = sanitised.replace(str(m), "*** MATCH ID ***")
         return sanitised
     except (json.decoder.JSONDecodeError, ValueError):
         return err_message

--- a/tests/unit/ecs_tasks/test_events.py
+++ b/tests/unit/ecs_tasks/test_events.py
@@ -145,5 +145,15 @@ def test_it_sanitises_matches(message_stub):
     )
 
 
+def test_it_sanitises_int_matches(message_stub):
+    assert (
+        "This message contains ID *** MATCH ID *** and *** MATCH ID ***"
+        == sanitize_message(
+            "This message contains ID 12345 and 23456",
+            message_stub(Columns=[{"Column": "a", "MatchIds": [12345, 23456, 34567]}]),
+        )
+    )
+
+
 def test_sanitiser_handles_malformed_messages():
     assert "an error message" == sanitize_message("an error message", "not json")


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
Fixes the Forget ECS Task match ID sanitiser to handle integers

*PR Checklist:*

- [x] Changelog updated
- [X] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [X] Pre-commit checks pass
- [X] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
