### PR TITLE
enable handling of parquet data with indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.10 (Unreleased)
+
+- [#193](https://github.com/awslabs/amazon-s3-find-and-forget/pull/193): Add
+  support for datasets with Pandas indexes. Pandas indexes will be preserved if
+  present.
+
 ## v0.9
 
 ### Summary

--- a/backend/ecs_tasks/delete_files/parquet.py
+++ b/backend/ecs_tasks/delete_files/parquet.py
@@ -49,7 +49,7 @@ def delete_from_table(table, to_delete, schema):
             df = df[~indexes]
     deleted_rows = initial_rows - get_row_count(df)
     table = pa.Table.from_pandas(
-        df, schema=schema, preserve_index=False
+        df, schema=schema, preserve_index=True
     ).replace_schema_metadata()
     return table, deleted_rows
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Sets preserve index to True when writing Parquet tables. This ensures that datasets which have been written with Pandas indexes can be processed by the solution. Previously an exception would be thrown because the original schema is specified when creating a PyArrow table from the updated pandas dataframe. For more information, see https://arrow.apache.org/docs/python/parquet.html#omitting-the-dataframe-index and https://github.com/apache/arrow/blob/8f3b029122a8f7149e2061c17a74f4add2677a6e/python/pyarrow/pandas_compat.py#L418

*PR Checklist:*

- [X] Changelog updated
- [X] Unit tests (and integration tests if applicable) provided
- [X] All tests pass
- [X] Pre-commit checks pass
- [X] Debugging code removed
- [X] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
