### PR TITLE
Extend the query queue visibility timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v0.10 (Unreleased)
+## v0.10
 
 - [#193](https://github.com/awslabs/amazon-s3-find-and-forget/pull/193): Add
   support for datasets with Pandas indexes. Pandas indexes will be preserved if
@@ -11,10 +11,10 @@
   support for requester pays buckets
 - [#196](https://github.com/awslabs/amazon-s3-find-and-forget/pull/196): Upgrade
   backend dependencies
+- [#197](https://github.com/awslabs/amazon-s3-find-and-forget/pull/197): Fix
+  duplicated query executions during Find Phase
 
 ## v0.9
-
-### Summary
 
 - [#189](https://github.com/awslabs/amazon-s3-find-and-forget/pull/189): UI
   Updates
@@ -22,8 +22,6 @@
   VPC template by default
 
 ## v0.8
-
-### Summary
 
 - [#185](https://github.com/awslabs/amazon-s3-find-and-forget/pull/185): Fix
   dead links to VPC info in docs
@@ -35,14 +33,10 @@
 
 ## v0.7
 
-### Summary
-
 - [#183](https://github.com/awslabs/amazon-s3-find-and-forget/pull/183):
   Dependency version updates for elliptic
 
 ## v0.6
-
-### Summary
 
 - [#173](https://github.com/awslabs/amazon-s3-find-and-forget/pull/173): Show
   column types and hierarchy in the front-end during Data Mapper creation
@@ -60,15 +54,11 @@
 
 ## v0.5
 
-### Summary
-
 - [#172](https://github.com/awslabs/amazon-s3-find-and-forget/pull/172): Fix for
   an issue where Make may not install the required Lambda layer dependencies,
   resulting in unusable builds.
 
 ## v0.4
-
-### Summary
 
 - [#171](https://github.com/awslabs/amazon-s3-find-and-forget/pull/171): Fix for
   a bug affecting the API for 5xx responses not returning the appropriate CORS
@@ -76,14 +66,10 @@
 
 ## v0.3
 
-### Summary
-
 - [#164](https://github.com/awslabs/amazon-s3-find-and-forget/pull/164): Fix for
   a bug affecting v0.2 deployment via CloudFormation
 
 ## v0.2
-
-### Summary
 
 - [#161](https://github.com/awslabs/amazon-s3-find-and-forget/pull/161): Fix for
   a bug affecting Parquet files with nullable values generating a
@@ -91,7 +77,5 @@
   Forget phase
 
 ## v0.1
-
-### Summary
 
 Initial Release

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -683,7 +683,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: alias/aws/sqs
-      VisibilityTimeout: 120
+      VisibilityTimeout: 1800
 
   # Tasks
   ParseStateMachineOutput:

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.9)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.10)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -135,7 +135,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.9'
+      Version: 'v0.10'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*
Extends the query queue visibility. This is for an issue I noticed: when processing a dataset with 31 partitions, I was noticing ~50 actual queries. This is because when it was taking more than 2m, the message was going back in the queue, despite the lambda would wait until completion and then correctly put the message in the deletion queue. The impact wasn't impacting functional behaviour (the deletion queue has deduplication) but still, it was impacting time and cost because of duplicated efforts on the Find phase.

With this PR I'm proposing we extend to 30m which is the duration Athena can take to complete a query.


*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
