### PR TITLE
Batch handling for deletion queue items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.11 (unreleased)
 
 - [#200](https://github.com/awslabs/amazon-s3-find-and-forget/pull/200): Add API
-  Endpoint for adding deletion queue items in batch
+  Endpoint for adding deletion queue items in batch - deprecates PATCH /v1/queue
 - [#170](https://github.com/awslabs/amazon-s3-find-and-forget/pull/170): JSON
   support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.11 (unreleased)
 
+- [#200](https://github.com/awslabs/amazon-s3-find-and-forget/pull/200): Add API
+  Endpoint for adding deletion queue items in batch
 - [#170](https://github.com/awslabs/amazon-s3-find-and-forget/pull/170): JSON
   support
 

--- a/docs/api/Apis/DeletionQueueApi.md
+++ b/docs/api/Apis/DeletionQueueApi.md
@@ -4,14 +4,15 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**AddToDeletionQueue**](DeletionQueueApi.md#addtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue
-[**DeleteMatches**](DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes an item from the deletion queue
+[**AddItemToDeletionQueue**](DeletionQueueApi.md#additemtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue
+[**AddItemsToDeletionQueue**](DeletionQueueApi.md#additemstodeletionqueue) | **PATCH** /v1/queue/matches | Adds one or more items to the deletion queue
+[**DeleteMatches**](DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes one or more items from the deletion queue
 [**ListDeletionQueueMatches**](DeletionQueueApi.md#listdeletionqueuematches) | **GET** /v1/queue | Lists deletion queue items
 [**StartDeletionJob**](DeletionQueueApi.md#startdeletionjob) | **DELETE** /v1/queue | Starts a job for the items in the deletion queue
 
 
-<a name="addtodeletionqueue"></a>
-## **AddToDeletionQueue**
+<a name="additemtodeletionqueue"></a>
+## **AddItemToDeletionQueue**
 
 Adds an item to the deletion queue
 
@@ -34,10 +35,34 @@ Name | Type | Description  | Notes
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+<a name="additemstodeletionqueue"></a>
+## **AddItemsToDeletionQueue**
+
+Adds one or more items to the deletion queue
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ListOfCreateDeletionQueueItems** | [**ListOfCreateDeletionQueueItems**](../Models/ListOfCreateDeletionQueueItems.md)|  |
+
+### Return type
+
+[**ListOfDeletionQueueItem**](../Models/ListOfDeletionQueueItem.md)
+
+### Authorization
+
+[CognitoAuthorizer](../README.md#CognitoAuthorizer)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
 <a name="deletematches"></a>
 ## **DeleteMatches**
 
-Removes an item from the deletion queue
+Removes one or more items from the deletion queue
 
 ### Parameters
 

--- a/docs/api/Apis/DeletionQueueApi.md
+++ b/docs/api/Apis/DeletionQueueApi.md
@@ -4,7 +4,7 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**AddItemToDeletionQueue**](DeletionQueueApi.md#additemtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue
+[**AddItemToDeletionQueue**](DeletionQueueApi.md#additemtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue (Deprecated: use PATCH /v1/queue/matches)
 [**AddItemsToDeletionQueue**](DeletionQueueApi.md#additemstodeletionqueue) | **PATCH** /v1/queue/matches | Adds one or more items to the deletion queue
 [**DeleteMatches**](DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes one or more items from the deletion queue
 [**ListDeletionQueueMatches**](DeletionQueueApi.md#listdeletionqueuematches) | **GET** /v1/queue | Lists deletion queue items
@@ -14,7 +14,7 @@ Method | HTTP request | Description
 <a name="additemtodeletionqueue"></a>
 ## **AddItemToDeletionQueue**
 
-Adds an item to the deletion queue
+Adds an item to the deletion queue (Deprecated: use PATCH /v1/queue/matches)
 
 ### Parameters
 

--- a/docs/api/Models/ListOfCreateDeletionQueueItems.md
+++ b/docs/api/Models/ListOfCreateDeletionQueueItems.md
@@ -1,0 +1,9 @@
+# ListOfCreateDeletionQueueItems
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Matches** | [**List**](CreateDeletionQueueItem.md) | List of Deletion Queue Items | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/docs/api/Models/ListOfDeletionQueueItem.md
+++ b/docs/api/Models/ListOfDeletionQueueItem.md
@@ -1,0 +1,9 @@
+# ListOfDeletionQueueItem
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Matches** | [**List**](DeletionQueueItem.md) | List of Deletion Queue Item objects | [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,8 +10,9 @@ API | Operation | HTTP request | Description
 *DataMapperApi* | [**CreateDataMapper**](./Apis/DataMapperApi.md#createdatamapper) | **PUT** /v1/data_mappers/{data_mapper_id} | Creates a data mapper
 *DataMapperApi* | [**DeleteDataMapper**](./Apis/DataMapperApi.md#deletedatamapper) | **DELETE** /v1/data_mappers/{data_mapper_id} | Removes a data mapper
 *DataMapperApi* | [**ListDataMappers**](./Apis/DataMapperApi.md#listdatamappers) | **GET** /v1/data_mappers | Lists data mappers
-*DeletionQueueApi* | [**AddToDeletionQueue**](./Apis/DeletionQueueApi.md#addtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue
-*DeletionQueueApi* | [**DeleteMatches**](./Apis/DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes an item from the deletion queue
+*DeletionQueueApi* | [**AddItemToDeletionQueue**](./Apis/DeletionQueueApi.md#additemtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue
+*DeletionQueueApi* | [**AddItemsToDeletionQueue**](./Apis/DeletionQueueApi.md#additemstodeletionqueue) | **PATCH** /v1/queue/matches | Adds one or more items to the deletion queue
+*DeletionQueueApi* | [**DeleteMatches**](./Apis/DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes one or more items from the deletion queue
 *DeletionQueueApi* | [**ListDeletionQueueMatches**](./Apis/DeletionQueueApi.md#listdeletionqueuematches) | **GET** /v1/queue | Lists deletion queue items
 *DeletionQueueApi* | [**StartDeletionJob**](./Apis/DeletionQueueApi.md#startdeletionjob) | **DELETE** /v1/queue | Starts a job for the items in the deletion queue
 *JobApi* | [**GetJob**](./Apis/JobApi.md#getjob) | **GET** /v1/jobs/{job_id} | Returns the details of a job
@@ -32,7 +33,9 @@ API | Operation | HTTP request | Description
  - [Job](./Models/Job.md)
  - [JobEvent](./Models/JobEvent.md)
  - [JobSummary](./Models/JobSummary.md)
+ - [ListOfCreateDeletionQueueItems](./Models/ListOfCreateDeletionQueueItems.md)
  - [ListOfDataMappers](./Models/ListOfDataMappers.md)
+ - [ListOfDeletionQueueItem](./Models/ListOfDeletionQueueItem.md)
  - [ListOfJobEvents](./Models/ListOfJobEvents.md)
  - [ListOfJobs](./Models/ListOfJobs.md)
  - [ListOfMatchDeletions](./Models/ListOfMatchDeletions.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,7 +10,7 @@ API | Operation | HTTP request | Description
 *DataMapperApi* | [**CreateDataMapper**](./Apis/DataMapperApi.md#createdatamapper) | **PUT** /v1/data_mappers/{data_mapper_id} | Creates a data mapper
 *DataMapperApi* | [**DeleteDataMapper**](./Apis/DataMapperApi.md#deletedatamapper) | **DELETE** /v1/data_mappers/{data_mapper_id} | Removes a data mapper
 *DataMapperApi* | [**ListDataMappers**](./Apis/DataMapperApi.md#listdatamappers) | **GET** /v1/data_mappers | Lists data mappers
-*DeletionQueueApi* | [**AddItemToDeletionQueue**](./Apis/DeletionQueueApi.md#additemtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue
+*DeletionQueueApi* | [**AddItemToDeletionQueue**](./Apis/DeletionQueueApi.md#additemtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue (Deprecated: use PATCH /v1/queue/matches)
 *DeletionQueueApi* | [**AddItemsToDeletionQueue**](./Apis/DeletionQueueApi.md#additemstodeletionqueue) | **PATCH** /v1/queue/matches | Adds one or more items to the deletion queue
 *DeletionQueueApi* | [**DeleteMatches**](./Apis/DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes one or more items from the deletion queue
 *DeletionQueueApi* | [**ListDeletionQueueMatches**](./Apis/DeletionQueueApi.md#listdeletionqueuematches) | **GET** /v1/queue | Lists deletion queue items

--- a/frontend/src/utils/gateway.js
+++ b/frontend/src/utils/gateway.js
@@ -35,9 +35,9 @@ export default {
   },
 
   enqueue(id, dataMappers) {
-    return apiGateway(`queue`, {
+    return apiGateway(`queue/matches`, {
       method: "patch",
-      data: { MatchId: id, DataMappers: dataMappers }
+      data: { Matches: [{ MatchId: id, DataMappers: dataMappers }] }
     });
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@openapitools/openapi-generator-cli": {
-      "version": "1.0.12-4.3.0",
-      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-1.0.12-4.3.0.tgz",
-      "integrity": "sha512-p6y0ur69/vEslpARrcWg3geujOAjxoQIlIamZGm1cWsu4y4RrEdrolueWA1Lxww2pUzgxvb9PwD6hHFZNNfgrw==",
+      "version": "1.0.18-4.3.1",
+      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-1.0.18-4.3.1.tgz",
+      "integrity": "sha512-t5OFeIfbD5bUQH3/5xoCHr96ay9nIKPgtlkN9YrX7Ce4q8NdSUU/bl83MJjzU8qcdDiwZtuUgqTM2Y4FLOi9CA==",
       "dev": true
     },
     "@types/eslint-visitor-keys": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {},
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "^1.0.12-4.3.0",
+    "@openapitools/openapi-generator-cli": "^1.0.18-4.3.1",
     "prettier-eslint-cli": "^5.0.0"
   },
   "scripts": {},

--- a/templates/api.definition.yml
+++ b/templates/api.definition.yml
@@ -79,7 +79,7 @@ paths:
       summary: Adds an item to the deletion queue
       tags:
         - DeletionQueue
-      operationId: "addToDeletionQueue"
+      operationId: "addItemToDeletionQueue"
       security:
         - CognitoAuthorizer: []
       responses:
@@ -106,7 +106,7 @@ paths:
         type: "aws_proxy"
   /v1/queue/matches:
     delete:
-      summary: Removes an item from the deletion queue
+      summary: Removes one or more items from the deletion queue
       tags:
         - DeletionQueue
       operationId: "deleteMatches"
@@ -141,6 +141,53 @@ paths:
       x-amazon-apigateway-integration:
         uri:
           Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CancelDeletion.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+        httpMethod: "POST"
+        type: "aws_proxy"
+    patch:
+      summary: Adds one or more items to the deletion queue
+      tags:
+        - DeletionQueue
+      operationId: "addItemsToDeletionQueue"
+      security:
+        - CognitoAuthorizer: []
+      responses:
+        '201':
+          description: "Created"
+          content:
+            application/json:
+              schema:
+                title: "ListOfDeletionQueueItem"
+                required:
+                  - "Matches"
+                type: "object"
+                properties:
+                  Matches:
+                    type: "array"
+                    description: "List of Deletion Queue Item objects"
+                    items:
+                      $ref: '#/components/schemas/DeletionQueueItem'
+        '422':
+          $ref: '#/components/responses/InvalidRequest'
+      requestBody:
+        description: "Request body containing details of the Matches to add to the Deletion Queue"
+        content:
+          application/json:
+            schema:
+              title: "ListOfCreateDeletionQueueItems"
+              required:
+                - "Matches"
+              type: "object"
+              properties:
+                Matches:
+                  type: "array"
+                  description: "List of Deletion Queue Items"
+                  items:
+                    $ref: '#/components/schemas/CreateDeletionQueueItem'
+        required: true
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EnqueueDeletions.Arn}/invocations"
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"

--- a/templates/api.definition.yml
+++ b/templates/api.definition.yml
@@ -76,7 +76,8 @@ paths:
         httpMethod: "POST"
         type: "aws_proxy"
     patch:
-      summary: Adds an item to the deletion queue
+      summary: "Adds an item to the deletion queue (Deprecated: use PATCH /v1/queue/matches)"
+      deprecated: true
       tags:
         - DeletionQueue
       operationId: "addItemToDeletionQueue"

--- a/templates/api.yaml
+++ b/templates/api.yaml
@@ -161,6 +161,21 @@ Resources:
       Policies:
       - DynamoDBCrudPolicy:
           TableName: !Ref DeletionQueueTableName
+  EnqueueDeletions:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers.enqueue_batch_handler
+      CodeUri: ../backend/lambdas/queue/
+      Events:
+        Get:
+          Type: Api
+          Properties:
+            Path: /v1/queue/matches
+            Method: PATCH
+            RestApiId: !Ref Api
+      Policies:
+      - DynamoDBCrudPolicy:
+          TableName: !Ref DeletionQueueTableName
   GetDeletionQueue:
     Type: AWS::Serverless::Function
     Properties:

--- a/tests/unit/apis/test_queue.py
+++ b/tests/unit/apis/test_queue.py
@@ -77,7 +77,7 @@ def test_it_adds_to_queue(table):
         },
         SimpleNamespace(),
     )
-
+    print(response["body"])
     assert 201 == response["statusCode"]
     assert {
         "DeletionQueueItemId": ANY,

--- a/tests/unit/apis/test_queue.py
+++ b/tests/unit/apis/test_queue.py
@@ -77,7 +77,6 @@ def test_it_adds_to_queue(table):
         },
         SimpleNamespace(),
     )
-    print(response["body"])
     assert 201 == response["statusCode"]
     assert {
         "DeletionQueueItemId": ANY,

--- a/tests/unit/apis/test_queue.py
+++ b/tests/unit/apis/test_queue.py
@@ -69,7 +69,7 @@ def test_it_retrieves_all_items_with_size_and_pagination(table):
 
 
 @patch("backend.lambdas.queue.handlers.deletion_queue_table")
-def test_it_add_to_queue(table):
+def test_it_adds_to_queue(table):
     response = handlers.enqueue_handler(
         {
             "body": json.dumps({"MatchId": "test", "DataMappers": ["a"]}),
@@ -85,6 +85,44 @@ def test_it_add_to_queue(table):
         "CreatedAt": ANY,
         "DataMappers": ["a"],
         "CreatedBy": {"Username": "cognitoUsername", "Sub": "cognitoSub"},
+    } == json.loads(response["body"])
+
+
+@patch("backend.lambdas.queue.handlers.deletion_queue_table")
+def test_it_adds_batch_to_queue(table):
+    response = handlers.enqueue_batch_handler(
+        {
+            "body": json.dumps(
+                {
+                    "Matches": [
+                        {"MatchId": "test", "DataMappers": ["a"]},
+                        {"MatchId": "test2", "DataMappers": ["a"]},
+                    ]
+                }
+            ),
+            "requestContext": autorization_mock,
+        },
+        SimpleNamespace(),
+    )
+
+    assert 201 == response["statusCode"]
+    assert {
+        "Matches": [
+            {
+                "DeletionQueueItemId": ANY,
+                "MatchId": "test",
+                "CreatedAt": ANY,
+                "DataMappers": ["a"],
+                "CreatedBy": {"Username": "cognitoUsername", "Sub": "cognitoSub"},
+            },
+            {
+                "DeletionQueueItemId": ANY,
+                "MatchId": "test2",
+                "CreatedAt": ANY,
+                "DataMappers": ["a"],
+                "CreatedBy": {"Username": "cognitoUsername", "Sub": "cognitoSub"},
+            },
+        ]
     } == json.loads(response["body"])
 
 


### PR DESCRIPTION
*Description of changes:*
Adds a batch endpoint to allow populating the queue quicker.
I'm not entirely sure of the API here, we already have a `PATCH /queue` for inserting an item, I thought we could just have a breaking change or keep the API of `queue/matches` compatible with the DELETE one (which uses that). So at least this is not breaking change.

One other thing I'm not sure is if we should set an arbitrary limit given we are subject to API Gateway payload size and response size, for instance 100 items or so?

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
