### PR TITLE
Fix acceptance tests

### DIFF
--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -45,7 +45,7 @@ def generate_parquet_file(items, columns):
 
 def query_parquet_file(f, column, val):
     table = pq.read_table(f)
-    return [i for i in table.column(column) if i == val]
+    return [i for i in table.column(column) if i.as_py() == val]
 
 
 def query_json_file(f, column, val):

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -50,7 +50,7 @@ def query_parquet_file(f, column, val):
 
 def query_json_file(f, column, val):
     table = pj.read_json(f)
-    return [i for i in table.column(column) if i == val]
+    return [i for i in table.column(column) if i.as_py() == val]
 
 
 def empty_table(table, pk, sk=None):

--- a/tests/acceptance/test_job.py
+++ b/tests/acceptance/test_job.py
@@ -232,6 +232,8 @@ def test_it_runs_for_parquet_happy_path(
         == job_table.get_item(Key={"Id": job_id, "Sk": job_id})["Item"]["JobStatus"]
     )
     assert 0 == len(query_parquet_file(tmp, "customer_id", "12345"))
+    assert 1 == len(query_parquet_file(tmp, "customer_id", "23456"))
+    assert 1 == len(query_parquet_file(tmp, "customer_id", "34567"))
     assert 2 == len(list(bucket.object_versions.filter(Prefix=object_key)))
     assert {"foo": "bar"} == bucket.Object(object_key).metadata
     assert "cache" == bucket.Object(object_key).cache_control
@@ -270,6 +272,8 @@ def test_it_runs_for_json_happy_path(
         == job_table.get_item(Key={"Id": job_id, "Sk": job_id})["Item"]["JobStatus"]
     )
     assert 0 == len(query_json_file(tmp.name, "customer_id", "12345"))
+    assert 1 == len(query_json_file(tmp.name, "customer_id", "23456"))
+    assert 1 == len(query_json_file(tmp.name, "customer_id", "34567"))
     assert 2 == len(list(bucket.object_versions.filter(Prefix=object_key)))
     assert {"foo": "bar"} == bucket.Object(object_key).metadata
     assert "cache" == bucket.Object(object_key).cache_control


### PR DESCRIPTION
*Issue #, if available:*
After upgrading pyarrow, a test was failing. I managed to reproduce with an old version and found out there were some changes on type coercion for strings when working directly with Arrow.

I also realised that somehow I didn't run a `make setup` during the last couple of iterations so the failure wasn't being reproduced locally.

Before:
```
for i in table.column(column):
  print(type(i))

<class 'pyarrow.lib.StringValue'>
<class 'pyarrow.lib.StringValue'>
<class 'pyarrow.lib.StringValue'>
```
After:
```
<class 'pyarrow.lib.StringScalar'>
<class 'pyarrow.lib.StringScalar'>
<class 'pyarrow.lib.StringScalar'>
```

*Description of changes:*
Use `as_py` to convert to Python string: https://arrow.apache.org/docs/python/generated/pyarrow.StringScalar.html#pyarrow.StringScalar.as_py

*PR Checklist:*

- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
