### PR TITLE
Fix query failures due to incorrect partition casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.12
+
+- [#TODO](https://github.com/awslabs/amazon-s3-find-and-forget/pull/TODO): Fix a
+  bug that was affecting Partitions with non-string types generating an error
+  during a
+  `SYNTAX_ERROR: line x:y: '=' cannot be applied to integer, varchar(4)`
+  exception during the Find Phase
+
 ## v0.11
 
 - [#200](https://github.com/awslabs/amazon-s3-find-and-forget/pull/200): Add API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## v0.12
+## v0.12 (unreleased)
 
-- [#TODO](https://github.com/awslabs/amazon-s3-find-and-forget/pull/TODO): Fix a
+- [#202](https://github.com/awslabs/amazon-s3-find-and-forget/pull/202): Fix a
   bug that was affecting Partitions with non-string types generating an error
   during a
   `SYNTAX_ERROR: line x:y: '=' cannot be applied to integer, varchar(4)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## v0.12 (unreleased)
 
 - [#202](https://github.com/awslabs/amazon-s3-find-and-forget/pull/202): Fix a
-  bug that was affecting Partitions with non-string types generating an error
-  during a
-  `SYNTAX_ERROR: line x:y: '=' cannot be applied to integer, varchar(4)`
+  bug that was affecting Partitions with non-string types generating a
+  `SYNTAX_ERROR: line x:y: '=' cannot be applied to integer, varchar(z)`
   exception during the Find Phase
 
 ## v0.11

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -256,6 +256,7 @@ def glue_table_factory(dummy_lake, glue_client, glue_columns):
         prefix="prefix",
         partition_keys=[],
         partitions=[],
+        partition_key_types="string",
     ):
         glue_client.create_database(DatabaseInput={"Name": database})
         input_format = (
@@ -292,7 +293,7 @@ def glue_table_factory(dummy_lake, glue_client, glue_columns):
                     "StoredAsSubDirectories": False,
                 },
                 "PartitionKeys": [
-                    {"Name": pk, "Type": "string",} for pk in partition_keys
+                    {"Name": pk, "Type": partition_key_types} for pk in partition_keys
                 ],
                 "Parameters": {"EXTERNAL": "TRUE"},
             },
@@ -353,6 +354,7 @@ def glue_data_mapper_factory(
         role_arn=None,
         delete_old_versions=False,
         column_identifiers=["customer_id"],
+        partition_key_types="string",
     ):
         item = {
             "DataMapperId": data_mapper_id,
@@ -377,6 +379,7 @@ def glue_data_mapper_factory(
             table=table,
             partition_keys=partition_keys,
             partitions=partitions,
+            partition_key_types=partition_key_types,
         )
 
         items.append(item)

--- a/tests/unit/tasks/test_execute_query.py
+++ b/tests/unit/tasks/test_execute_query.py
@@ -68,6 +68,42 @@ def test_it_generates_query_with_partition():
     )
 
 
+def test_it_generates_query_with_partition_and_int_column():
+    resp = make_query(
+        {
+            "Database": "amazonreviews",
+            "Table": "amazon_reviews_parquet",
+            "Columns": [{"Column": "customer_id", "MatchIds": [123456, 456789]}],
+            "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
+        }
+    )
+
+    assert (
+        escape_resp(resp) == 'SELECT DISTINCT "$path" '
+        'FROM "amazonreviews"."amazon_reviews_parquet" '
+        'WHERE ("customer_id" in (123456, 456789)) '
+        "AND \"product_category\" = 'Books'"
+    )
+
+
+def test_it_generates_query_with_int_partition():
+    resp = make_query(
+        {
+            "Database": "amazonreviews",
+            "Table": "amazon_reviews_parquet",
+            "Columns": [{"Column": "customer_id", "MatchIds": ["123456", "456789"]}],
+            "PartitionKeys": [{"Key": "year", "Value": 2010}],
+        }
+    )
+
+    assert (
+        escape_resp(resp) == 'SELECT DISTINCT "$path" '
+        'FROM "amazonreviews"."amazon_reviews_parquet" '
+        "WHERE (\"customer_id\" in ('123456', '456789')) "
+        'AND "year" = 2010'
+    )
+
+
 def test_it_generates_query_with_multiple_partitions():
     resp = make_query(
         {

--- a/tests/unit/tasks/test_generate_queries.py
+++ b/tests/unit/tasks/test_generate_queries.py
@@ -133,7 +133,7 @@ class TestAthenaQueries:
         partition_keys = ["year"]
         partitions = [["2010"]]
         get_table_mock.return_value = table_stub(
-            columns, partition_keys, partition_key_types="int"
+            columns, partition_keys, partition_keys_type="int"
         )
         get_partitions_mock.return_value = [
             partition_stub(p, columns) for p in partitions
@@ -739,7 +739,7 @@ def partition_stub(values, columns, table_name="test_table"):
 
 
 def table_stub(
-    columns, partition_keys, table_name="test_table", partition_key_types="string"
+    columns, partition_keys, table_name="test_table", partition_keys_type="string"
 ):
     return {
         "Name": table_name,
@@ -771,7 +771,7 @@ def table_stub(
             "StoredAsSubDirectories": False,
         },
         "PartitionKeys": [
-            {"Name": partition_key, "Type": partition_key_types}
+            {"Name": partition_key, "Type": partition_keys_type}
             for partition_key in partition_keys
         ],
         "TableType": "EXTERNAL_TABLE",

--- a/tests/unit/tasks/test_generate_queries.py
+++ b/tests/unit/tasks/test_generate_queries.py
@@ -10,11 +10,12 @@ with patch.dict(os.environ, {"QueryQueue": "test"}):
         handler,
         get_table,
         get_partitions,
-        convert_to_col_type,
+        cast_to_type,
         get_deletion_queue,
         generate_athena_queries,
         get_data_mappers,
         get_inner_children,
+        get_nested_children,
     )
 
 pytestmark = [pytest.mark.unit, pytest.mark.task]
@@ -121,6 +122,45 @@ class TestAthenaQueries:
                 "Table": "test_table",
                 "Columns": [{"Column": "customer_id", "MatchIds": ["hi"]}],
                 "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
+                "DeleteOldVersions": True,
+            }
+        ]
+
+    @patch("backend.lambdas.tasks.generate_queries.get_table")
+    @patch("backend.lambdas.tasks.generate_queries.get_partitions")
+    def test_it_handles_int_partitions(self, get_partitions_mock, get_table_mock):
+        columns = ["customer_id"]
+        partition_keys = ["year"]
+        partitions = [["2010"]]
+        get_table_mock.return_value = table_stub(
+            columns, partition_keys, partition_key_types="int"
+        )
+        get_partitions_mock.return_value = [
+            partition_stub(p, columns) for p in partitions
+        ]
+        resp = generate_athena_queries(
+            {
+                "DataMapperId": "a",
+                "QueryExecutor": "athena",
+                "Columns": columns,
+                "Format": "parquet",
+                "QueryExecutorParameters": {
+                    "DataCatalogProvider": "glue",
+                    "Database": "test_db",
+                    "Table": "test_table",
+                },
+            },
+            [{"MatchId": "hi"}],
+        )
+        assert resp == [
+            {
+                "DataMapperId": "a",
+                "QueryExecutor": "athena",
+                "Format": "parquet",
+                "Database": "test_db",
+                "Table": "test_table",
+                "Columns": [{"Column": "customer_id", "MatchIds": ["hi"]}],
+                "PartitionKeys": [{"Key": "year", "Value": 2010}],
                 "DeleteOldVersions": True,
             }
         ]
@@ -537,7 +577,7 @@ class TestAthenaQueries:
             {"value": "2.23", "type": "double", "expected": 2.23},
             {"value": "2.23", "type": "float", "expected": 2.23},
         ]:
-            res = convert_to_col_type(
+            res = cast_to_type(
                 scenario["value"],
                 "test_col",
                 {
@@ -559,12 +599,12 @@ class TestAthenaQueries:
             {"value": "1234567890", "id": "user.info.user_id", "expected": 1234567890},
             {"value": "1", "id": "user.type", "expected": 1},
         ]:
-            res = convert_to_col_type(scenario["value"], scenario["id"], table)
+            res = cast_to_type(scenario["value"], scenario["id"], table)
             assert res == scenario["expected"]
 
     def test_it_throws_for_unknown_col(self):
         with pytest.raises(ValueError):
-            convert_to_col_type(
+            cast_to_type(
                 "mystr",
                 "doesnt_exist",
                 {
@@ -584,7 +624,7 @@ class TestAthenaQueries:
             "map<string,struct<x:int>>",
         ]:
             with pytest.raises(ValueError):
-                convert_to_col_type(
+                cast_to_type(
                     123,
                     "user.x",
                     {
@@ -596,7 +636,7 @@ class TestAthenaQueries:
 
     def test_it_throws_for_unsupported_col_types(self):
         with pytest.raises(ValueError) as e:
-            convert_to_col_type(
+            cast_to_type(
                 "2.56",
                 "test_col",
                 {
@@ -612,7 +652,7 @@ class TestAthenaQueries:
 
     def test_it_throws_for_unconvertable_matches(self):
         with pytest.raises(ValueError):
-            convert_to_col_type(
+            cast_to_type(
                 "mystr",
                 "test_col",
                 {
@@ -622,9 +662,17 @@ class TestAthenaQueries:
                 },
             )
 
-    def test_it_throws_for_invalid_schema(self):
-        with pytest.raises(ValueError):
+    def test_it_throws_for_invalid_schema_for_inner_children(self):
+        with pytest.raises(ValueError) as e:
             get_inner_children("struct<name:string", "struct<", ">")
+        assert e.value.args[0] == "Column schema is not valid"
+
+    def test_it_throws_for_invalid_schema_for_nested_children(self):
+        with pytest.raises(ValueError) as e:
+            get_nested_children(
+                "struct<name:string,age:int,s:struct<n:int>,b:string", "struct"
+            )
+        assert e.value.args[0] == "Column schema is not valid"
 
 
 @patch("backend.lambdas.tasks.generate_queries.jobs_table")
@@ -690,7 +738,9 @@ def partition_stub(values, columns, table_name="test_table"):
     }
 
 
-def table_stub(columns, partition_keys, table_name="test_table"):
+def table_stub(
+    columns, partition_keys, table_name="test_table", partition_key_types="string"
+):
     return {
         "Name": table_name,
         "DatabaseName": "test",
@@ -721,7 +771,7 @@ def table_stub(columns, partition_keys, table_name="test_table"):
             "StoredAsSubDirectories": False,
         },
         "PartitionKeys": [
-            {"Name": partition_key, "Type": "string"}
+            {"Name": partition_key, "Type": partition_key_types}
             for partition_key in partition_keys
         ],
         "TableType": "EXTERNAL_TABLE",


### PR DESCRIPTION
*Description of changes*
Adds handling for non-string partition types such as int. I opted for keeping the strategy consistent with what we do with matches: we get the partition type from glue, then we cast it during the generate phase, so that the execute inherits the values already casted. 

Credits: I took some code snippets from @ormahler's #188 PR 

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
