### PR TITLE
Fix Firefox cors issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   frontend dependencies
 - [#204](https://github.com/awslabs/amazon-s3-find-and-forget/pull/204): Improve
   performance during Cleanup Phase
+- [#205](https://github.com/awslabs/amazon-s3-find-and-forget/pull/205): Fix a
+  UI issue affecting FireFox preventing to show the correct queue size due to a
+  missing CORS header
 
 ## v0.11
 

--- a/backend/lambdas/queue/handlers.py
+++ b/backend/lambdas/queue/handlers.py
@@ -89,6 +89,7 @@ def get_handler(event, context):
         "body": json.dumps(
             {"MatchIds": items, "NextStart": next_start}, cls=DecimalEncoder
         ),
+        "headers": {"Access-Control-Expose-Headers": "content-length"},
     }
 
 

--- a/tests/acceptance/test_queue.py
+++ b/tests/acceptance/test_queue.py
@@ -125,6 +125,7 @@ def test_it_rejects_invalid_add_to_queue(api_client, queue_base_endpoint, stack)
     )
 
 
+@pytest.mark.only
 def test_it_gets_queue(api_client, queue_base_endpoint, del_queue_factory, stack):
     # Arrange
     del_queue_item = del_queue_factory()
@@ -139,6 +140,7 @@ def test_it_gets_queue(api_client, queue_base_endpoint, del_queue_factory, stack
         response.headers.get("Access-Control-Allow-Origin")
         == stack["APIAccessControlAllowOriginHeader"]
     )
+    assert response.headers.get("Access-Control-Expose-Headers") == "content-length"
 
 
 def test_it_rejects_invalid_deletion(

--- a/tests/acceptance/test_queue.py
+++ b/tests/acceptance/test_queue.py
@@ -125,7 +125,6 @@ def test_it_rejects_invalid_add_to_queue(api_client, queue_base_endpoint, stack)
     )
 
 
-@pytest.mark.only
 def test_it_gets_queue(api_client, queue_base_endpoint, del_queue_factory, stack):
     # Arrange
     del_queue_item = del_queue_factory()


### PR DESCRIPTION
*Description of changes:*
I noticed a bug affecting the UI for showing the correct Deletion queue size (for instance Chrome 1(~258 bytes) vs Firefox 1(0 bytes). After some digging, I found firefox is more strict about content-length and needs a header for the frontend to be able to read it (we base the approximate size of the queue to the content-length of the queue api responses).

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
