### PR TITLE
Remove ambiguity between DataMappers Create/Modify/Put

### DIFF
--- a/docs/api/Apis/DataMapperApi.md
+++ b/docs/api/Apis/DataMapperApi.md
@@ -4,35 +4,10 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**CreateDataMapper**](DataMapperApi.md#createdatamapper) | **PUT** /v1/data_mappers/{data_mapper_id} | Creates a data mapper
 [**DeleteDataMapper**](DataMapperApi.md#deletedatamapper) | **DELETE** /v1/data_mappers/{data_mapper_id} | Removes a data mapper
 [**ListDataMappers**](DataMapperApi.md#listdatamappers) | **GET** /v1/data_mappers | Lists data mappers
+[**PutDataMapper**](DataMapperApi.md#putdatamapper) | **PUT** /v1/data_mappers/{data_mapper_id} | Creates or modifies a data mapper
 
-
-<a name="createdatamapper"></a>
-## **CreateDataMapper**
-
-Creates a data mapper
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **DataMapperId** | **String**| Data Mapper ID path parameter | [default to null]
- **DataMapper** | [**DataMapper**](../Models/DataMapper.md)| Request body containing details of the Data Mapper to create |
-
-### Return type
-
-[**DataMapper**](../Models/DataMapper.md)
-
-### Authorization
-
-[CognitoAuthorizer](../README.md#CognitoAuthorizer)
-
-### HTTP request headers
-
-- **Content-Type**: application/json
-- **Accept**: application/json
 
 <a name="deletedatamapper"></a>
 ## **DeleteDataMapper**
@@ -81,5 +56,30 @@ Name | Type | Description  | Notes
 ### HTTP request headers
 
 - **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="putdatamapper"></a>
+## **PutDataMapper**
+
+Creates or modifies a data mapper
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **DataMapperId** | **String**| Data Mapper ID path parameter | [default to null]
+ **DataMapper** | [**DataMapper**](../Models/DataMapper.md)| Request body containing details of the Data Mapper to create or modify |
+
+### Return type
+
+[**DataMapper**](../Models/DataMapper.md)
+
+### Authorization
+
+[CognitoAuthorizer](../README.md#CognitoAuthorizer)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
 - **Accept**: application/json
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -7,9 +7,9 @@ All URIs are relative to *https://your-apigw-id.execute-api.region.amazonaws.com
 
 API | Operation | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*DataMapperApi* | [**CreateDataMapper**](./Apis/DataMapperApi.md#createdatamapper) | **PUT** /v1/data_mappers/{data_mapper_id} | Creates a data mapper
 *DataMapperApi* | [**DeleteDataMapper**](./Apis/DataMapperApi.md#deletedatamapper) | **DELETE** /v1/data_mappers/{data_mapper_id} | Removes a data mapper
 *DataMapperApi* | [**ListDataMappers**](./Apis/DataMapperApi.md#listdatamappers) | **GET** /v1/data_mappers | Lists data mappers
+*DataMapperApi* | [**PutDataMapper**](./Apis/DataMapperApi.md#putdatamapper) | **PUT** /v1/data_mappers/{data_mapper_id} | Creates or modifies a data mapper
 *DeletionQueueApi* | [**AddItemToDeletionQueue**](./Apis/DeletionQueueApi.md#additemtodeletionqueue) | **PATCH** /v1/queue | Adds an item to the deletion queue (Deprecated: use PATCH /v1/queue/matches)
 *DeletionQueueApi* | [**AddItemsToDeletionQueue**](./Apis/DeletionQueueApi.md#additemstodeletionqueue) | **PATCH** /v1/queue/matches | Adds one or more items to the deletion queue
 *DeletionQueueApi* | [**DeleteMatches**](./Apis/DeletionQueueApi.md#deletematches) | **DELETE** /v1/queue/matches | Removes one or more items from the deletion queue

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -411,6 +411,10 @@ form .form-check-label {
   width: 100%;
 }
 
+.form-error {
+  color: #d13212;
+}
+
 /* MODAL */
 .modal-backdrop {
   background-color: hsla(180, 4%, 95%, 0.9);

--- a/templates/api.definition.yml
+++ b/templates/api.definition.yml
@@ -344,10 +344,10 @@ paths:
     parameters:
       - '$ref': '#/components/parameters/DataMapperId'
     put:
-      summary: Creates a data mapper
+      summary: Creates or modifies a data mapper
       tags:
         - DataMapper
-      operationId: "createDataMapper"
+      operationId: "putDataMapper"
       security:
         - CognitoAuthorizer: []
       responses:
@@ -358,7 +358,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DataMapper'
       requestBody:
-        description: "Request body containing details of the Data Mapper to create"
+        description: "Request body containing details of the Data Mapper to create or modify"
         content:
           application/json:
             schema:
@@ -366,7 +366,7 @@ paths:
         required: true
       x-amazon-apigateway-integration:
         uri:
-          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CreateDataMapper.Arn}/invocations"
+          Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PutDataMapper.Arn}/invocations"
         passthroughBehavior: "when_no_match"
         httpMethod: "POST"
         type: "aws_proxy"

--- a/templates/api.yaml
+++ b/templates/api.yaml
@@ -231,10 +231,10 @@ Resources:
             Effect: "Allow"
             Resource: !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ConfigParameter}"
   # DataMappers
-  CreateDataMapper:
+  PutDataMapper:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: handlers.create_data_mapper_handler
+      Handler: handlers.put_data_mapper_handler
       CodeUri: ../backend/lambdas/data_mappers/
       Events:
         Put:


### PR DESCRIPTION
*Description of changes:*

At the moment the PUT data mapper is advertised as Create in API/Frontend and I think this generates confusion. I renamed the "Create" in the backend to be PUT in order to be consistent with API behaviour. I also found and fixed a bug involving doing a PUT for an existing DM that had the same location being prevented from being modified.

In the frontend, I think it makes sense to keep the naming and behaviour as "create", so I decided to add a check to prevent adding a new data mapper with the same ID both on validation phase (by fetching all DMs on page load and then checking synchronously against that) and submit phase (checking one last time to reduce probability of a race condition).

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
