### PR TITLE
Fix SF state limit on submit results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 
-## v0.14 (unreleased)
+## v0.14
 
+- [#213](https://github.com/awslabs/amazon-s3-find-and-forget/pull/213): Fix for
+  a bug causing a FIND_FAILED error related to a States.DataLimitExceed
+  exception triggered by Step Function's Athena workflow when executing the
+  SubmitQueryResults lambda
 - [#208](https://github.com/awslabs/amazon-s3-find-and-forget/pull/208): Fix bug
   preventing PUT DataMapper to edit existing datamapper with same location, fix
   Front-end DataMapper creation to prevent editing an existing one.

--- a/backend/lambdas/tasks/submit_query_results.py
+++ b/backend/lambdas/tasks/submit_query_results.py
@@ -45,4 +45,4 @@ def handler(event, context):
 
     batch_sqs_msgs(queue, messages)
 
-    return paths
+    return len(paths)

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -224,9 +224,7 @@ Resources:
               "Next": "Query Succeeded",
               "Retry": [{
                  "ErrorEquals": [ "States.ALL" ],
-                 "IntervalSeconds": 5,
-                 "BackoffRate": 2.5,
-                 "MaxAttempts": 1
+                 "MaxAttempts": 0
               }],
               "Catch": [{
                  "ErrorEquals": ["States.ALL"],

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.13)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.14)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -135,7 +135,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.13'
+      Version: 'v0.14'
 
 Resources:
   TempBucket:

--- a/tests/unit/tasks/test_submit_query_results.py
+++ b/tests/unit/tasks/test_submit_query_results.py
@@ -31,7 +31,7 @@ def test_it_returns_only_paths(paginate_mock, batch_sqs_msgs_mock):
         },
         SimpleNamespace(),
     )
-    assert ["s3://mybucket/mykey1", "s3://mybucket/mykey2",] == resp
+    assert 2 == resp
 
 
 @patch("backend.lambdas.tasks.submit_query_results.batch_sqs_msgs")


### PR DESCRIPTION
*Description of changes:*

This fixes a FIND_FAILED during querying a dataset that has a large number of results (managed to reproduce with 5000 objects as result in a single partition) triggering an error such as:
```
{
  "Error": "States.DataLimitExceeded",
  "Cause": "The state/task 'arn:aws:lambda:[redacted]:[redacted]:function:S3F2-StateMachineStack-[redacted]-SubmitQueryResults-[redacted]' returned a result with a size exceeding the maximum number of bytes service limit."
}
```

The reason is that the lambda that stores the results in SQS, then returns the full paths as result, which affects the SF state limit (regardless of excluding it with `ResultPath: null`).
I managed to verify that after this change, the execution succeeds.

As a side note, when I was testing (and the step was failing) I noticed that when retrying, because of the 5m timeslot for deduplication on the Fifo deletion queue (5K items take a while to be batched into SQS) all the messages were being duplicated, which can have unwanted consequences. As a result, I decided to decrease the number of retries to 0 as I think it's safer way to handle that failure scenario (fail fast rather than keep trying and very likely fail later). 

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
