### PR TITLE
Include base image in artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ build.zip
 packaged.zip
 frontend/public/settings.js
 *.sentinel
+backend/ecs_tasks/*.tar
 
 # docs
 .openapi-generator/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## v0.18
+
+- [#223](https://github.com/awslabs/amazon-s3-find-and-forget/pull/223): This
+  release fixes
+  [an issue (#222)](https://github.com/awslabs/amazon-s3-find-and-forget/issues/222)
+  where new deployments of the solution could fail due to unavailability of a
+  third-party dependency. Container base images are now retrieved and bundled
+  with each release.
+
 ## v0.17
 
 - [#220](https://github.com/awslabs/amazon-s3-find-and-forget/pull/220): Fix for

--- a/Makefile
+++ b/Makefile
@@ -85,13 +85,18 @@ package:
 	make package-artefacts
 	zip -r packaged.zip templates backend cfn-publish.config build.zip -x **/__pycache* -x *settings.js
 
-package-artefacts:
+package-artefacts: backend/ecs_tasks/python_3.7-slim.tar
 	make build-frontend
 	zip -r build.zip \
 		backend/ecs_tasks/delete_files/ \
+		backend/ecs_tasks/python_3.7-slim.tar \
 		backend/lambda_layers/boto_utils/ \
 		frontend/build \
 		-x 'backend/ecs_tasks/delete_files/__pycache*' '*settings.js' @
+
+backend/ecs_tasks/python_3.7-slim.tar:
+	docker pull python:3.7-slim
+	docker save python:3.7-slim -o "$@"
 
 redeploy-containers:
 	$(eval ACCOUNT_ID := $(shell aws sts get-caller-identity --query Account --output text))

--- a/Makefile
+++ b/Makefile
@@ -83,16 +83,21 @@ lint-cfn:
 
 package:
 	make package-artefacts
-	zip -r packaged.zip templates backend cfn-publish.config build.zip -x **/__pycache* -x *settings.js
+	zip -r packaged.zip \
+		backend/lambda_layers \
+		backend/lambdas \
+		build.zip \
+		cfn-publish.config \
+		templates \
+		-x '**/__pycache*' '*settings.js' @
 
 package-artefacts: backend/ecs_tasks/python_3.7-slim.tar
 	make build-frontend
 	zip -r build.zip \
-		backend/ecs_tasks/delete_files/ \
-		backend/ecs_tasks/python_3.7-slim.tar \
+		backend/ecs_tasks/ \
 		backend/lambda_layers/boto_utils/ \
 		frontend/build \
-		-x 'backend/ecs_tasks/delete_files/__pycache*' '*settings.js' @
+		-x '**/__pycache*' '*settings.js' @
 
 backend/ecs_tasks/python_3.7-slim.tar:
 	docker pull python:3.7-slim

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -147,6 +147,7 @@ Resources:
                 - IMAGE_URI="${REPOSITORY_URI}"
             build:
               commands:
+                - docker load -i backend/ecs_tasks/python_3.7-slim.tar
                 - docker build --tag "$IMAGE_URI" -f backend/ecs_tasks/delete_files/Dockerfile .
             post_build:
               commands:

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.17)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.18)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -135,7 +135,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.17'
+      Version: 'v0.18'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Issue #, if available:* #222 

*Description of changes:*

This commit attempts to address #222 by moving the Docker base image
retrieval to the build/release CI stage and including it in the release
artefacts. This version is then loaded in CodeBuild using `docker load`.

Although bundling the docker base image in the packaged artefacts isn't
particularly elegant, it addresses some constraints we have at this
particular time around creating new distribution channels. We may be
able to revisit and improve upon this later.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
