### PR TITLE
Handle Deleted Glue Tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.21 (unreleased)
+
+- [#232](https://github.com/awslabs/amazon-s3-find-and-forget/pull/232): Fix for
+  a bug affecting the Frontend not rendering the Data Mappers list when a Glue
+  Table associated to a Data Mapper gets deleted
+
 ## v0.20
 
 - [#230](https://github.com/awslabs/amazon-s3-find-and-forget/pull/230): Upgrade

--- a/frontend/src/components/BucketPolicyModal.js
+++ b/frontend/src/components/BucketPolicyModal.js
@@ -8,13 +8,14 @@ const { athenaExecutionRole, region } = window.s3f2Settings;
 const BucketPolicyModal = ({
   accountId,
   bucket,
-  roleArn,
   close,
-  show,
-  location
+  error,
+  location,
+  roleArn,
+  show
 }) => {
   const [key, setKey] = useState("bucket");
-  const locationWithoutProtocol = location.replace("s3://", "");
+  const locationWithoutProtocol = (location || "").replace("s3://", "");
   const tabs = [
     {
       key: "bucket",
@@ -48,23 +49,32 @@ const BucketPolicyModal = ({
         <Modal.Title>Generate Policies</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <p>
-          After configuring a data mapper, you need to configure the relevant S3
-          bucket, Customer Managed CMK and IAM policies to enable the solution
-          to read and write from/to the bucket. The policy statements provided
-          below are examples of how to grant the required access.
-        </p>
-        <Tabs activeKey={key} onSelect={k => setKey(k)}>
-          {tabs.map(tab => (
-            <Tab
-              key={tab.key}
-              eventKey={tab.key}
-              title={<span>{tab.title}</span>}
-            >
-              {tab.content}
-            </Tab>
-          ))}
-        </Tabs>
+        {error ? (
+          <Alert type="error" title="An Error Occurred">
+            {error}
+          </Alert>
+        ) : (
+          <>
+            <p>
+              After configuring a data mapper, you need to configure the
+              relevant S3 bucket, Customer Managed CMK and IAM policies to
+              enable the solution to read and write from/to the bucket. The
+              policy statements provided below are examples of how to grant the
+              required access.
+            </p>
+            <Tabs activeKey={key} onSelect={k => setKey(k)}>
+              {tabs.map(tab => (
+                <Tab
+                  key={tab.key}
+                  eventKey={tab.key}
+                  title={<span>{tab.title}</span>}
+                >
+                  {tab.content}
+                </Tab>
+              ))}
+            </Tabs>
+          </>
+        )}
       </Modal.Body>
       <Modal.Footer>
         <Button className="aws-button action-button" onClick={close}>

--- a/frontend/src/components/CellError.js
+++ b/frontend/src/components/CellError.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+import Icon from "./Icon";
+
+const CellError = ({ error }) => (
+  <>
+    <Icon type="alert-warning" />
+    <span style={{ marginLeft: "4px", color: "#d13212" }}>{error}</span>
+  </>
+);
+
+export default CellError;

--- a/frontend/src/utils/glueSerializer.js
+++ b/frontend/src/utils/glueSerializer.js
@@ -200,11 +200,12 @@ export const bucketMapper = tables => {
 
   tables.forEach(
     t =>
-      (result[`${t.Table.DatabaseName}/${t.Table.Name}`] = {
-        bucket: t.Table.StorageDescriptor.Location.split("/")[2],
-        location: t.Table.StorageDescriptor.Location
-      })
+      (result[`${t.Table.DatabaseName}/${t.Table.Name}`] = t.error
+        ? t
+        : {
+            bucket: t.Table.StorageDescriptor.Location.split("/")[2],
+            location: t.Table.StorageDescriptor.Location
+          })
   );
-
   return result;
 };

--- a/frontend/src/utils/retryWrapper.js
+++ b/frontend/src/utils/retryWrapper.js
@@ -6,7 +6,8 @@ export const retryWrapper = (p, timeout, retryN) =>
     p()
       .then(resolve)
       .catch(e => {
-        if (retryN === MAX_RETRIES) return reject(e);
+        const retryable = e?.response?.status !== 400;
+        if (retryN === MAX_RETRIES || !retryable) return reject(e);
         const t = (timeout || RETRY_START / 2) * 2;
         const r = (retryN || 0) + 1;
         console.log(`Retry n. ${r} in ${t / 1000}s...`);


### PR DESCRIPTION
*Description of changes:*
When a Glue Table is deleted, the Data Mappers UI fails to render the list because the Glue API call fails - and the whole UI is unusable. This PR is to show the error and handle deletion/policy generation (which shows an error message from the API).

![Screenshot 2021-01-11 at 17 35 26](https://user-images.githubusercontent.com/1789893/104218319-7a310e80-5434-11eb-8889-ae41153fa298.png)
![Screenshot 2021-01-11 at 17 35 44](https://user-images.githubusercontent.com/1789893/104218332-80bf8600-5434-11eb-8b04-d5707dc39f32.png)


*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
