### PR TITLE
Improve query generation code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v0.21 (unreleased)
+## v0.21
 
 - [#232](https://github.com/awslabs/amazon-s3-find-and-forget/pull/232): Fix for
   a bug affecting the Frontend not rendering the Data Mappers list when a Glue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   Table associated to a Data Mapper gets deleted
 - [#233](https://github.com/awslabs/amazon-s3-find-and-forget/pull/233): Add GET
   endpoint for specific data mapper
+- [#234](https://github.com/awslabs/amazon-s3-find-and-forget/pull/234):
+  Performance improvements for the query generation phase
 
 ## v0.20
 

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.20)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.21)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -135,7 +135,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.20'
+      Version: 'v0.21'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*
While working on #198 I discovered that the code for query generation can be improved. We currently create a template of a query object at the beginning of the code snippet, then we duplicate it for any partition combination, and only then, we workout all the queue elements for each partition. Because there is no difference between partitions in terms of queue items logic, we can just workout the queue items earlier and just once, and duplicate for partitioned buckets at the end instead, saving in compute time and making the code a bit simpler.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
