### PR TITLE
Allow to specify granularity for partition querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.30 (unreleased)
+
+- [#257](https://github.com/awslabs/amazon-s3-find-and-forget/pull/257):
+  Introduce data mapper setting to specify the partition keys to be used when
+  querying the data during the Find Phase
+
 ## v0.29
 
 - [#256](https://github.com/awslabs/amazon-s3-find-and-forget/pull/256): Upgrade

--- a/backend/lambdas/tasks/generate_queries.py
+++ b/backend/lambdas/tasks/generate_queries.py
@@ -211,19 +211,16 @@ def generate_athena_queries(data_mapper, deletion_items, job_id):
     # For every partition combo of every table, create a query
     partitions = []
     for partition in get_partitions(db, table_name):
-        current = []
-        for i, v in enumerate(partition["Values"]):
-            if all_partition_keys[i] in partition_keys:
-                current.append(
-                    {
-                        "Key": all_partition_keys[i],
-                        "Value": cast_to_type(v, all_partition_keys[i], table, True),
-                    }
-                )
-        duplicate = next((x for x in partitions if x == current), None)
-        if not duplicate:
+        current = [
+            {
+                "Key": all_partition_keys[i],
+                "Value": cast_to_type(v, all_partition_keys[i], table, True),
+            }
+            for i, v in enumerate(partition["Values"])
+            if all_partition_keys[i] in partition_keys
+        ]
+        if not next((x for x in partitions if x == current), None):
             partitions.append(current)
-
     return [{**msg, "PartitionKeys": x} for x in partitions]
 
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -398,8 +398,23 @@ To grant these permissions in Lake Formation:
    have a greater number of smaller queries (the same query will be repeated
    with a `WHERE` additional clause for each combination of partition values).
    If you have a lot of small partitions, it may be more efficient to choose
-   none or a subset of partition keys from the list. If instead you have very
-   big partitions you may want to select all the partition keys.
+   none or a subset of partition keys from the list in order to increase speed
+   of execution. If instead you have very big partitions, it may be more
+   efficient to choose all the partition keys in order to reduce probability of
+   failure caused by query timeout. As a rule of thumb, we recommend the average
+   query size to be between 100GB and 1TB.
+
+   > As an example, let's consider 10 years of daily data with partition keys of
+   > `year`, `month` and `day` with total size of `100TB`. By declaring
+   > PartitionKeys=`[]` (none) a single query of 100TB would run during the Find
+   > phase, and that may be too much to complete within the 30m limit of Athena
+   > execution time. On the other hand, using all the combinations of the
+   > partition keys we would have approximately `3650` queries, each being
+   > probably very small, and given the default Athena concurrency limit of
+   > `20`, it may take very long to execute all of them. The best in this
+   > scenario is possibly the `['year','month']` combination, which would result
+   > in `120` queries.
+
 6. From the columns list, choose the column(s) the solution should use to to
    find items in the data which should be deleted. For example, if your table
    has three columns named **customer_id**, **description** and **created_at**

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -401,8 +401,8 @@ To grant these permissions in Lake Formation:
    none or a subset of partition keys from the list in order to increase speed
    of execution. If instead you have very big partitions, it may be more
    efficient to choose all the partition keys in order to reduce probability of
-   failure caused by query timeout. As a rule of thumb, we recommend the average
-   query size to be between 100GB and 1TB.
+   failure caused by query timeout. We recommend the average query size to be
+   between 100GB and 1TB.
 
    > As an example, let's consider 10 years of daily data with partition keys of
    > `year`, `month` and `day` with total size of `100TB`. By declaring

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -401,15 +401,15 @@ To grant these permissions in Lake Formation:
    none or a subset of partition keys from the list in order to increase speed
    of execution. If instead you have very big partitions, it may be more
    efficient to choose all the partition keys in order to reduce probability of
-   failure caused by query timeout. We recommend the average query size to be
-   between 100GB and 1TB.
+   failure caused by query timeout. We recommend the average query size not to
+   exceed the hundreds of GBs and not to take more than 5 minutes.
 
    > As an example, let's consider 10 years of daily data with partition keys of
-   > `year`, `month` and `day` with total size of `100TB`. By declaring
-   > PartitionKeys=`[]` (none) a single query of 100TB would run during the Find
-   > phase, and that may be too much to complete within the 30m limit of Athena
-   > execution time. On the other hand, using all the combinations of the
-   > partition keys we would have approximately `3650` queries, each being
+   > `year`, `month` and `day` with total size of `10TB`. By declaring
+   > PartitionKeys=`[]` (none) a single query of `10TB` would run during the
+   > Find phase, and that may be too much to complete within the 30m limit of
+   > Athena execution time. On the other hand, using all the combinations of the
+   > partition keys we would have approximately `3652` queries, each being
    > probably very small, and given the default Athena concurrency limit of
    > `20`, it may take very long to execute all of them. The best in this
    > scenario is possibly the `['year','month']` combination, which would result

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -392,24 +392,32 @@ To grant these permissions in Lake Formation:
 4. Select a **Query Executor Type** then choose the **Database** and **Table**
    in your data catalog which describes the target data in S3. A list of columns
    will be displayed for the chosen Table.
-5. From the list, choose the column(s) the solution should use to to find items
-   in the data which should be deleted. For example, if your table has three
-   columns named **customer_id**, **description** and **created_at** and you
-   want to search for items using the **customer_id**, you should choose only
-   the **customer_id** column from this list.
-6. Enter the ARN of the role for Fargate to assume when modifying objects in S3
+5. From the Partition Keys list, select the partition key(s) that you want the
+   solution to use when generating the queries. If you select none, only one
+   query will be performed for the data mapper. If you select any or all, you'll
+   have a bigger number of smaller queries (the same query will be repeated with
+   a `WHERE` additional clause for each combination of partition values). If you
+   have a lot of small partitions, you may choose none or few partition keys
+   from the list. If instead you have very big partitions you may want to select
+   all the partition keys.
+6. From the columns list, choose the column(s) the solution should use to to
+   find items in the data which should be deleted. For example, if your table
+   has three columns named **customer_id**, **description** and **created_at**
+   and you want to search for items using the **customer_id**, you should choose
+   only the **customer_id** column from this list.
+7. Enter the ARN of the role for Fargate to assume when modifying objects in S3
    buckets. This role should already exist if you have followed the
    [Provisioning Data Access IAM Roles](#provisioning-data-access-iam-roles)
    steps.
-7. If you do not want the solution to delete all older versions except the
+8. If you do not want the solution to delete all older versions except the
    latest created object version, deselect _Delete previous object versions
    after update_. By default the solution will delete all previous of versions
    after creating a new version.
-8. Choose **Create Data Mapper**.
-9. A message is displayed advising you to update the S3 Bucket Policy for the S3
-   Bucket referenced by the newly created data mapper. See
-   [Granting Access to Data](#granting-access-to-data) for more information on
-   how to do this. Choose **Return to Data Mappers**.
+9. Choose **Create Data Mapper**.
+10. A message is displayed advising you to update the S3 Bucket Policy for the
+    S3 Bucket referenced by the newly created data mapper. See
+    [Granting Access to Data](#granting-access-to-data) for more information on
+    how to do this. Choose **Return to Data Mappers**.
 
 You can also create Data Mappers directly via the API. For more information, see
 the [API Documentation].

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -395,9 +395,9 @@ To grant these permissions in Lake Formation:
 5. From the Partition Keys list, select the partition key(s) that you want the
    solution to use when generating the queries. If you select none, only one
    query will be performed for the data mapper. If you select any or all, you'll
-   have a bigger number of smaller queries (the same query will be repeated with
+   have a greater number of smaller queries (the same query will be repeated with
    a `WHERE` additional clause for each combination of partition values). If you
-   have a lot of small partitions, you may choose none or few partition keys
+   have a lot of small partitions, it may be more efficient to choose none or a subset of partition keys
    from the list. If instead you have very big partitions you may want to select
    all the partition keys.
 6. From the columns list, choose the column(s) the solution should use to to

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -395,11 +395,11 @@ To grant these permissions in Lake Formation:
 5. From the Partition Keys list, select the partition key(s) that you want the
    solution to use when generating the queries. If you select none, only one
    query will be performed for the data mapper. If you select any or all, you'll
-   have a greater number of smaller queries (the same query will be repeated with
-   a `WHERE` additional clause for each combination of partition values). If you
-   have a lot of small partitions, it may be more efficient to choose none or a subset of partition keys
-   from the list. If instead you have very big partitions you may want to select
-   all the partition keys.
+   have a greater number of smaller queries (the same query will be repeated
+   with a `WHERE` additional clause for each combination of partition values).
+   If you have a lot of small partitions, it may be more efficient to choose
+   none or a subset of partition keys from the list. If instead you have very
+   big partitions you may want to select all the partition keys.
 6. From the columns list, choose the column(s) the solution should use to to
    find items in the data which should be deleted. For example, if your table
    has three columns named **customer_id**, **description** and **created_at**

--- a/docs/api/Models/DataMapperQueryExecutorParameters.md
+++ b/docs/api/Models/DataMapperQueryExecutorParameters.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **DataCatalogProvider** | [**String**](string.md) | The data catalog provider which contains the database table with metadata about your S3 data lake | [optional] [default to null] [enum: glue]
 **Database** | [**String**](string.md) | The database in the data catalog which contains the metatadata table | [default to null]
 **Table** | [**String**](string.md) | The table in the data catalog database containing the metatadata for your data lake | [default to null]
+**PartitionKeys** | [**List**](string.md) | The partition keys to use on each query. This allows to control the number and the size of the queries. When omitted, all the table partitions are used. | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "REACT_APP_REPO_URL=$npm_package_repository_url SKIP_PREFLIGHT_CHECK=true react-scripts build",
+    "dev": "SKIP_PREFLIGHT_CHECK=true react-scripts test",
     "eject": "react-scripts eject",
     "package": "cd build && zip -r ../../frontend.zip . -x *settings.js",
     "start": "HTTPS=true SKIP_PREFLIGHT_CHECK=true REACT_APP_REPO_URL=$npm_package_repository_url react-scripts start",

--- a/frontend/src/__tests__/__snapshots__/glueSerializer.js.snap
+++ b/frontend/src/__tests__/__snapshots__/glueSerializer.js.snap
@@ -16,6 +16,9 @@ Object {
           ],
           "format": "parquet",
           "name": "table1",
+          "partitionKeys": Array [
+            "product_category",
+          ],
         },
         Object {
           "columns": Array [
@@ -27,6 +30,7 @@ Object {
           ],
           "format": "parquet",
           "name": "table2",
+          "partitionKeys": Array [],
         },
       ],
     },
@@ -43,6 +47,9 @@ Object {
           ],
           "format": "parquet",
           "name": "table5",
+          "partitionKeys": Array [
+            "product_category",
+          ],
         },
         Object {
           "columns": Array [
@@ -91,6 +98,11 @@ Object {
           ],
           "format": "json",
           "name": "table3",
+          "partitionKeys": Array [
+            "partition_0",
+            "partition_1",
+            "partition_2",
+          ],
         },
       ],
     },
@@ -286,6 +298,7 @@ Object {
           ],
           "format": "parquet",
           "name": "complex",
+          "partitionKeys": Array [],
         },
       ],
     },

--- a/frontend/src/components/pages/DataMappers.js
+++ b/frontend/src/components/pages/DataMappers.js
@@ -191,38 +191,43 @@ const DataMappers = ({ gateway, onPageChange }) => {
           </thead>
           <tbody>
             {dataMappers &&
-              dataMappers.map((dataMapper, index) => (
-                <tr
-                  key={index}
-                  className={selectedRow === index ? "selected" : undefined}
-                >
-                  <td style={{ textAlign: "center" }}>
-                    <Form.Check
-                      inline
-                      type="radio"
-                      id={`inline-${index}`}
-                      name="item"
-                      onClick={() => selectRow(index)}
-                    />
-                  </td>
-                  <td>{dataMapper.DataMapperId}</td>
-                  <td>{dataMapper.Columns.join(", ")}</td>
-                  <td>{dataMapper.Format}</td>
-                  <td>{dataMapper.QueryExecutor}</td>
-                  <td>
-                    {dataMapper.QueryExecutorParameters.Database}/
-                    {dataMapper.QueryExecutorParameters.Table} (
-                    {dataMapper.QueryExecutorParameters.DataCatalogProvider})
-                  </td>
-                  <td>
-                    {getBucket(index).error ? (
-                      <CellError error={getBucket(index).error} />
-                    ) : (
-                      getBucket(index).location
-                    )}
-                  </td>
-                </tr>
-              ))}
+              dataMappers.map((dataMapper, index) => {
+                const qep = dataMapper.QueryExecutorParameters;
+                const pk = qep.PartitionKeys;
+                return (
+                  <tr
+                    key={index}
+                    className={selectedRow === index ? "selected" : undefined}
+                  >
+                    <td style={{ textAlign: "center" }}>
+                      <Form.Check
+                        inline
+                        type="radio"
+                        id={`inline-${index}`}
+                        name="item"
+                        onClick={() => selectRow(index)}
+                      />
+                    </td>
+                    <td>{dataMapper.DataMapperId}</td>
+                    <td>{dataMapper.Columns.join(", ")}</td>
+                    <td>{dataMapper.Format}</td>
+                    <td>{dataMapper.QueryExecutor}</td>
+                    <td>
+                      {qep.DataCatalogProvider}: {qep.Database}/{qep.Table}
+                      <br />
+                      (partition keys:{" "}
+                      {pk ? (isEmpty(pk) ? `None` : pk.join(", ")) : "ALL"})
+                    </td>
+                    <td>
+                      {getBucket(index).error ? (
+                        <CellError error={getBucket(index).error} />
+                      ) : (
+                        getBucket(index).location
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
           </tbody>
         </Table>
         {isEmpty(dataMappers) && formState !== "initial" && (

--- a/frontend/src/components/pages/DataMappers.js
+++ b/frontend/src/components/pages/DataMappers.js
@@ -203,7 +203,7 @@ const DataMappers = ({ gateway, onPageChange }) => {
                       <Form.Check
                         inline
                         type="radio"
-                        id={`inline-${index}`}
+                        id={`dm-${index}`}
                         name="item"
                         onClick={() => selectRow(index)}
                       />

--- a/frontend/src/components/pages/DeletionJob.js
+++ b/frontend/src/components/pages/DeletionJob.js
@@ -245,18 +245,38 @@ const DeletionJob = ({ gateway, jobId }) => {
               )}
               <span>{withDefault(job.TotalQueryFailedCount)}</span>
             </DetailsBox>
-            <DetailsBox label="Total Query Time">
+            <DetailsBox label="Total Query Time" noSeparator>
               {withDefault(
                 job.TotalQueryTimeInMillis,
                 (x) => `${(x / 1000).toFixed(0)}s`
               )}
             </DetailsBox>
-            <DetailsBox label="Total Query Scanned Bytes">
+            <DetailsBox label="Total Query Scanned Bytes" noSeparator>
               {withDefault(
                 job.TotalQueryScannedInBytes,
                 (x) => `${x} ${x > 0 ? "(" + formatFileSize(x) + ")" : ""}`
               )}
             </DetailsBox>
+            <DetailsBox label="Individual Query Time Average">
+              {isUndefined(job.GeneratedQueries)
+                ? "-"
+                : withDefault(
+                    job.TotalQueryTimeInMillis / job.GeneratedQueries,
+                    (x) => `${(x / 1000).toFixed(0)}s`
+                  )}
+            </DetailsBox>
+            <DetailsBox label="Individual Query Scanned Bytes Average">
+              {isUndefined(job.GeneratedQueries)
+                ? "-"
+                : withDefault(
+                    job.TotalQueryScannedInBytes / job.GeneratedQueries,
+                    (x) =>
+                      `${x.toFixed(0)} ${
+                        x > 0 ? "(" + formatFileSize(x) + ")" : ""
+                      }`
+                  )}
+            </DetailsBox>
+
             <DetailsBox label="Total Object Updated Count" noSeparator>
               {withDefault(job.TotalObjectUpdatedCount)}
             </DetailsBox>

--- a/frontend/src/components/pages/NewDataMapper.js
+++ b/frontend/src/components/pages/NewDataMapper.js
@@ -364,7 +364,7 @@ const NewDataMapper = ({ gateway, goToDataMappers }) => {
                     : isEmpty(partitionKeysForSelectedTable)
                     ? `None - the table is not partitioned`
                     : `In order to control the granularity of each query, you can
-                      select none or more partition keys to be used. If you
+                      select the partition keys to be used in the query phase. If you
                       select none, only one query will be performed for the data
                       mapper. If you select all, you'll have the higher amount
                       of smaller queries.`}
@@ -378,7 +378,7 @@ const NewDataMapper = ({ gateway, goToDataMappers }) => {
                 <Form.Label>Columns used to query for matches</Form.Label>
                 <Form.Text className="text-muted">
                   {!isEmpty(columnsForSelectedTable)
-                    ? `Select one or more column from the table`
+                    ? `Select one or more columns from the table`
                     : `No table selected`}
                 </Form.Text>
                 <ColumnsViewer

--- a/frontend/src/components/pages/NewDataMapper.js
+++ b/frontend/src/components/pages/NewDataMapper.js
@@ -363,11 +363,11 @@ const NewDataMapper = ({ gateway, goToDataMappers }) => {
                     ? `No table selected`
                     : isEmpty(partitionKeysForSelectedTable)
                     ? `None - the table is not partitioned`
-                    : `In order to control the granularity of each query, you can
+                    : `To control the granularity of each query, you can
                       select the partition keys to be used in the query phase. If you
                       select none, only one query will be performed for the data
-                      mapper. If you select all, you'll have the higher amount
-                      of smaller queries.`}
+                      mapper. If you select all, more queries will be run to scan each partition
+                      of the data separately.`}
                 </Form.Text>
                 <PartitionKeysViewer
                   partitionKeys={partitionKeysForSelectedTable}

--- a/frontend/src/components/pages/NewDataMapper.js
+++ b/frontend/src/components/pages/NewDataMapper.js
@@ -53,20 +53,19 @@ const ColumnsViewer = ({
 
 const PartitionKeysViewer = ({ partitionKeys, setPartitionKeys }) =>
   partitionKeys.map((pk, index) => (
-    <Fragment key={`pkv-${index}`}>
-      <Form.Check
-        type="checkbox"
-        id={`cb-pkv-${index}`}
-        name="partition-key"
-        label={pk}
-        onChange={(e) =>
-          setPartitionKeys({
-            type: e.target.checked ? "add" : "remove",
-            partitionKey: pk,
-          })
-        }
-      ></Form.Check>
-    </Fragment>
+    <Form.Check
+      type="checkbox"
+      key={`pkv-${index}`}
+      id={`cb-pkv-${index}`}
+      name="partition-key"
+      label={pk}
+      onChange={(e) =>
+        setPartitionKeys({
+          type: e.target.checked ? "add" : "remove",
+          partitionKey: pk,
+        })
+      }
+    />
   ));
 
 const NewDataMapper = ({ gateway, goToDataMappers }) => {

--- a/frontend/src/utils/gateway.js
+++ b/frontend/src/utils/gateway.js
@@ -169,7 +169,16 @@ const gateway = {
     return apiGateway("queue", { method: "del" });
   },
 
-  putDataMapper(id, db, table, columns, roleArn, deleteOldVersions, format) {
+  putDataMapper(
+    id,
+    db,
+    table,
+    columns,
+    partitionKeys,
+    roleArn,
+    deleteOldVersions,
+    format
+  ) {
     return apiGateway(`data_mappers/${id}`, {
       method: "put",
       data: {
@@ -179,7 +188,8 @@ const gateway = {
         QueryExecutorParameters: {
           DataCatalogProvider: "glue",
           Database: db,
-          Table: table
+          Table: table,
+          PartitionKeys: partitionKeys
         },
         Format: format,
         RoleArn: roleArn,

--- a/frontend/src/utils/glueSerializer.js
+++ b/frontend/src/utils/glueSerializer.js
@@ -185,6 +185,7 @@ export const glueSerializer = tables => {
         tables: supportedTables.map(t => ({
           name: t.Name,
           columns: t.StorageDescriptor.Columns.map(columnMapper),
+          partitionKeys: t.PartitionKeys.map(pk => pk.Name),
           format:
             t.StorageDescriptor.SerdeInfo.SerializationLibrary === PARQUET_SERDE
               ? "parquet"

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -91,3 +91,12 @@ export const docsUrl = x => repoUrl(`blob/master/docs/${trimLeadingSlash(x)}`);
 
 export const findMin = (arr, key) =>
   arr.reduce((prev, curr) => (prev[key] < curr[key] ? prev : curr));
+
+export const multiValueArrayReducer = (state, action) => {
+  if (action.type === "add" && !state.includes(action.value))
+    return [...state, action.value];
+  if (action.type === "remove" && state.includes(action.value))
+    return state.filter(x => x !== action.value);
+  if (action.type === "reset") return action.value || [];
+  return state;
+};

--- a/templates/api.definition.yml
+++ b/templates/api.definition.yml
@@ -506,6 +506,11 @@ components:
             Table:
               description: "The table in the data catalog database containing the metatadata for your data lake"
               type: "string"
+            PartitionKeys:
+              description: "The partition keys to use on each query. This allows to control the number and the size of the queries. When omitted, all the table partitions are used."
+              type: "array"
+              items:
+                type: "string"
           required:
             - "Database"
             - "Table"


### PR DESCRIPTION
*Description of changes:*

This is a PR to enable customers to customise the query strategy by declaring the Partition Keys to be used for generating queries.

Let's take an example a large dataset with Partition Keys=[year,month,day] as 3 individual partition keys.
The solution as today will fetch the cartesian product of them and will perform a query for each unique combination of values. 

For example, let's assume daily data starting Feb 1st 2020 and ending March 1st 2021.
With this new feature, a Data Mapper will be able to specify none or any of the Partition Keys:
* With `PartitionKeys=[]` there will be 1 query (no partition keys used)
* With `PartitionKeys=["year"]` there will be 2 queries (y=2020 + y=2021)
* With `PartitionKeys=["month"]` there will be 12 queries
* With `PartitionKeys=["year","month"]` there will be 13 queries
* etc..
* By omitting `PartitionKeys` we'll have a default of all, equivalent to `["year","month","day"]` for backward compatibility (365+28 if I'm doing the math right 😂 )

This feature was requested by customers with very large amount of very small partitions - that currently need to wait hours for a deletion job to complete, that given the very small amount of data should be able to query without partitioning in minutes instead - therefore saving in athena concurrency and overall lambda cost.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
