### PR TITLE
Fix creating data mapper bug when glue table doesn't have partition keys

### DIFF
--- a/frontend/src/utils/glueSerializer.js
+++ b/frontend/src/utils/glueSerializer.js
@@ -185,7 +185,7 @@ export const glueSerializer = tables => {
         tables: supportedTables.map(t => ({
           name: t.Name,
           columns: t.StorageDescriptor.Columns.map(columnMapper),
-          partitionKeys: t.PartitionKeys.map(pk => pk.Name),
+          partitionKeys: t.PartitionKeys ? t.PartitionKeys.map(pk => pk.Name) : [],
           format:
             t.StorageDescriptor.SerdeInfo.SerializationLibrary === PARQUET_SERDE
               ? "parquet"


### PR DESCRIPTION
*Issue #, if available:*
If glue table(s) doesn't contain partition keys, it will fail when creating a new data mapper.
*Description of changes:*
Add a check for partition keys in the glue serializer.
*PR Checklist:*

- [ ] Changelog updated
- [ ] Unit tests (and integration tests if applicable) provided
- [ ] All tests pass
- [ ] Pre-commit checks pass
- [ ] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
