### PR TITLE
Fix STS frontend bug

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,12 +8,12 @@
       "name": "amazon-s3-find-and-forget-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-amplify/ui-components": "^1.7.8",
-        "@aws-amplify/ui-react": "^1.2.15",
+        "@aws-amplify/ui-components": "^1.8.2",
+        "@aws-amplify/ui-react": "^1.2.19",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.3.2",
         "@testing-library/user-event": "^7.1.2",
-        "aws-amplify": "^4.2.9",
+        "aws-amplify": "^4.3.1",
         "bootstrap": "^4.4.1",
         "react": "^16.14.0",
         "react-bootstrap": "^1.0.0",
@@ -23,12 +23,12 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.0.15.tgz",
-      "integrity": "sha512-AP++UPU/rmXJ6Z+id5WBDSR4ioMkMYlPDlBZl0zIl67Om+J4G3Q0zJ6Q5ft6oZOkGotw+7smI3hBRSBoeF6kxg==",
+      "version": "5.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.0.19.tgz",
+      "integrity": "sha512-TDnDOTjb1gZ9ASs8JyiejVB8nIU79BMq5CSEsuBDOg7WpM5zeIRC5dXpdfw2e92w5W+ACr9vTKwmgv8c2JYeow==",
       "dependencies": {
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-firehose": "3.6.1",
         "@aws-sdk/client-kinesis": "3.6.1",
         "@aws-sdk/client-personalize-events": "3.6.1",
@@ -48,24 +48,24 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.15.tgz",
-      "integrity": "sha512-GTm8d5PLstQxwYA+b7OPBCMarc4Nwp4A5VFxYsXHI63fOShXhqCX9Le6Ivnk0X1Vcg9hrtips//qkRFjOQyEiw==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.19.tgz",
+      "integrity": "sha512-+bP1sSAkRlbId/cCBYrPkaqybvOBRK8ldolr5CH5pWhWKGWO0FsjDRMu7gQI4wKGDk3NdmB40XUa+abT2jPz2g==",
       "dependencies": {
-        "@aws-amplify/api-graphql": "2.2.4",
-        "@aws-amplify/api-rest": "2.0.15"
+        "@aws-amplify/api-graphql": "2.2.8",
+        "@aws-amplify/api-rest": "2.0.19"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.4.tgz",
-      "integrity": "sha512-ZNeOe6p8GGAPN7A1wDTfwRyfJUlMraB0K/dAUiUqb8pPmdaqq9YYbAmJ9h+7itDZ5/gahGeByx8CAhomylwwsA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.8.tgz",
+      "integrity": "sha512-FMwUUNkK/WU6xCRfxDuxGZPay+Lbiz6i4rvD7mfUfeCc7zN8sZa832Buu+0CwYhlC75PlQOeU23UARDwWcConQ==",
       "dependencies": {
-        "@aws-amplify/api-rest": "2.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/pubsub": "4.1.7",
+        "@aws-amplify/api-rest": "2.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/pubsub": "4.1.11",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
@@ -81,37 +81,37 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.15.tgz",
-      "integrity": "sha512-jGPwdV2egaIoxV5sHR9UcjQtloE8hf6/ZavZdDSlOSmfztC20kfK5y+UibYdZdD4DroTrKkSlkRt9XiaXLq1tw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.19.tgz",
+      "integrity": "sha512-FvEV/nX5beeD0zHTvwIcCrrgSfWymhvvrcDX7L5RPoitv415sruXcbj0e6ODCAm0Aw2bieW2K2fXIQ1gNa0JtQ==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
         "axios": "0.21.4"
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.5.tgz",
-      "integrity": "sha512-EhlpiMh3yIMR0Df79TQqp0z37gKpHAp1+QBRmwp0NSDAM8JMpGwt/rb7+WGyEMLVVhMMb24YuE75UshhNegQcQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.9.tgz",
+      "integrity": "sha512-E61GTg9GaHAsC5NrRqD1JGMHWvyWKeMjD8Cjt9kZEwQq7Y33oP9KJ7vUinSpGi2Eh2pnJSXg5z23Xx8BGVZeag==",
       "dependencies": {
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "amazon-cognito-identity-js": "5.1.0",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "amazon-cognito-identity-js": "5.2.0",
         "crypto-js": "^4.1.1"
       }
     },
     "node_modules/@aws-amplify/cache": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.17.tgz",
-      "integrity": "sha512-I+ND9ZU65dZXIT0VR+du7qZTq61vdFJdL5uhNCh7XQATJCqJtulH86csMpfJ6gosQM3+pcg4rEPQSgDnqPaE3w==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.21.tgz",
+      "integrity": "sha512-tJK9ShFq4LJgOGrGI3ilr0bxrNLXLmmAsRpPwfqyQvKG7ZyUI9r8K5sQi8ov8QIhr/ogoDpQOeWcN5Fhp3Gj2A==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9"
+        "@aws-amplify/core": "4.3.1"
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.2.9.tgz",
-      "integrity": "sha512-a5xSu1fOQNxgpQsfuUkJbzRBkoD+JcasdfMpXGcgYr1Iuj5Sua4xcLe4Z9O4VaGaUy1Y7laHDP4aa+Mn/RJq9w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.3.1.tgz",
+      "integrity": "sha512-qYQIs95F/AdBGbUFNXzKp3nAFPpQtivvBGOFQa+plqK/mzV23fh33BxRh/Hc3A+bcfpM8lBDZbIn9LPVRj3VLA==",
       "dependencies": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
         "@aws-sdk/client-cloudwatch-logs": "3.6.1",
@@ -124,15 +124,15 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.3.tgz",
-      "integrity": "sha512-XgjyzOX6bY+zAsv/ylvX0aeElZfbpzq0X8bw9Zx1zrb9wIGOYfSjDC3HzeffoGkFBb/lOscFvN1jbAsxQygWsw==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.7.tgz",
+      "integrity": "sha512-UB9CdZCC397Gl3G8neIxTx86JSFL27ftMNIKPrYTvWQEF2sKy5zP7Kr572pW60I5cw7+FERlH3BJ+SIbzYcuKg==",
       "dependencies": {
-        "@aws-amplify/api": "4.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/pubsub": "4.1.7",
-        "amazon-cognito-identity-js": "5.1.0",
+        "@aws-amplify/api": "4.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/pubsub": "4.1.11",
+        "amazon-cognito-identity-js": "5.2.0",
         "idb": "5.0.6",
         "immer": "9.0.6",
         "ulid": "2.3.0",
@@ -159,22 +159,32 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/@aws-amplify/interactions": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.15.tgz",
-      "integrity": "sha512-OaLAGzu/gu2GNDZLX41i1bT67eEnBJiyyS/eh5c3skrFvYI3zyjAEzD3cIsOVU2LwhnLZRMNSwoXNqAlkFbtHQ==",
+    "node_modules/@aws-amplify/geo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-1.1.1.tgz",
+      "integrity": "sha512-sasyp6l+/ZMXcCVWaKyEZiV7hGGzTQV9D3dbU1iqi6/BHEFRfJxnubt3P39XaR672SQ1e8qhFDx36TiL5mePcA==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-sdk/client-location": "3.22.0",
+        "camelcase-keys": "6.2.2"
+      }
+    },
+    "node_modules/@aws-amplify/interactions": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.19.tgz",
+      "integrity": "sha512-g33BUZbMkI6Qkwa9KyCCHMaoUmprY8XVJRVuamVo6+3qCMZXn5KDXa/cTad7+NCASDzMo/XWb65vmWeo9hyw8Q==",
+      "dependencies": {
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-lex-runtime-service": "3.6.1"
       }
     },
     "node_modules/@aws-amplify/predictions": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.15.tgz",
-      "integrity": "sha512-bfsWlRd6ZyV5PbqSohpug9KzW5GR82K2UdFU+s90UPCHuj78eSFLflttl/ako95u7tFFFq4MUWtC+rWX5+miMQ==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.19.tgz",
+      "integrity": "sha512-bHT7gYECVLkkcenQ8filTqeDndx+PrV1MlncYfgsaZp0xjnZ4WaQsvIvSf+ZUvQxk3ayzn85p0MRwPKJR4yEqQ==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/storage": "4.3.10",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/storage": "4.4.2",
         "@aws-sdk/client-comprehend": "3.6.1",
         "@aws-sdk/client-polly": "3.6.1",
         "@aws-sdk/client-rekognition": "3.6.1",
@@ -195,13 +205,13 @@
       }
     },
     "node_modules/@aws-amplify/pubsub": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.7.tgz",
-      "integrity": "sha512-ES9E4utrsers96bHl1E7clKZanlH9modcjjovJPswLi85q0tybTAG+fi9QRYHp07XSN+EjmEF4Jxrw47w4Hmzw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.11.tgz",
+      "integrity": "sha512-Z7xZ244LY6sIK2i6NIBkhuZGXhcVPLFLhyZc1adACuxDWPnZo0Xtiu6SWdZ1Sf575iHRHBCg6DG6TWf8m1YpaA==",
       "dependencies": {
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
         "graphql": "14.0.0",
         "paho-mqtt": "^1.1.0",
         "uuid": "^3.2.1",
@@ -218,11 +228,11 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.3.10.tgz",
-      "integrity": "sha512-Mplgkd+mmWxoB7P4m+0UK++Nb+97eeH7/ZKemLIFL8s8N1n2voQZJLK9uTkY3vvIS17sT9QvWCMl63v6TPnebw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.4.2.tgz",
+      "integrity": "sha512-BjdDq+PcKCS7taMcwc3moKEIykw0vfgzKBClSBBwyXP5ewHQJNYMhe7sGlVt17MyFBTQkBVWJtt9QsvcNcw98w==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-s3": "3.6.1",
         "@aws-sdk/s3-request-presigner": "3.6.1",
         "@aws-sdk/util-create-request": "3.6.1",
@@ -238,9 +248,9 @@
       "integrity": "sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A=="
     },
     "node_modules/@aws-amplify/ui-components": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-1.7.8.tgz",
-      "integrity": "sha512-BR31SXO5ppyhhOkw+Qys2sSkDV0rjHDO/5NAkJwP9OhOm47QgIIaKCdTurIYnaskelMflKgetVAts+2xUymegg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-1.8.2.tgz",
+      "integrity": "sha512-w+iJh66itkpZ13MSmIL0LW5frrk4dP9FdcH5KvGAgUDjLSM4dOqeBa1wuPHHJ5pkilByZMK9LHkqP7TIAMdWdA==",
       "dependencies": {
         "qrcode": "^1.4.4",
         "uuid": "^8.2.0"
@@ -250,11 +260,11 @@
       }
     },
     "node_modules/@aws-amplify/ui-react": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.15.tgz",
-      "integrity": "sha512-baBOFmJiuqiaeEZaT/TW2ZjxcsdciwiCTFC2qaOXJHMNAYyUzMXY7mOHeaNblBrI+uzppm4dvjVPqmB8zcjr7A==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.19.tgz",
+      "integrity": "sha512-qf+XZujT/i8eNHgV7P5P2UGCTzJldrgYCdSW15jSJhPSZ3iJNvHjVbeB7FAdIIm2hH65/WJkF2kixsf5G6rwEQ==",
       "dependencies": {
-        "@aws-amplify/ui-components": "1.7.8"
+        "@aws-amplify/ui-components": "1.8.2"
       },
       "peerDependencies": {
         "react": ">= 16.7.0",
@@ -262,18 +272,20 @@
       }
     },
     "node_modules/@aws-amplify/xr": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.15.tgz",
-      "integrity": "sha512-sINduNuGaPjeyZ/9iDbzevHyNWiHRHYeDVfzbgNFE8lf92uqN3m1rN8acg7wJHjnaDpw/0qFPGzN/tT+s/SvDg==",
+      "version": "3.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.19.tgz",
+      "integrity": "sha512-wogJDDVLXrDribhhW/OUK8ZTqFAmVuDHn8O/tusBOdpnjfYULddDML6BSBtYMsP3TGkOz7c7v/HPTtWBfRR2ZQ==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9"
+        "@aws-amplify/core": "4.3.1"
       }
     },
     "node_modules/@aws-crypto/crc32": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.1.0.tgz",
-      "integrity": "sha512-ifvfaaJVvT+JUTi3zSkX4wtuGGVJrAcjN7ftg+JiE/frNBP3zNwo4xipzWBsMLZfNuzMZuaesEYyqkZcs5tzCQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.2.1.tgz",
+      "integrity": "sha512-Ydso55lIn3Vudui5jXNKcxmyVr9BNWeIkAhleGuG9zpb0Pu5yXf2Jth2A07fUyLSXX2gwfv0d84zwvKK2FMbuA==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
         "tslib": "^1.11.1"
       }
     },
@@ -286,26 +298,26 @@
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.1.tgz",
-      "integrity": "sha512-nS4vdan97It6HcweV58WXtjPbPSc0JXd3sAwlw3Ou5Mc3WllSycAS32Tv2LRn8butNQoU9AE3jEQAOgiMdNC1Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.1.tgz",
+      "integrity": "sha512-WX/Wp6sXPhcBWx/w1aSJv3bDJL0ut5Ik6hl7yfqA1pn3cfsahl4rgHzRRXqYfJ+hnhnCqdgadS17wyBbVPsK+w==",
       "dependencies": {
         "@aws-crypto/ie11-detection": "^1.0.0",
-        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/sha256-js": "^1.2.1",
         "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -340,6 +352,16 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
       "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.1.tgz",
+      "integrity": "sha512-H6Qrl28lzGGXZgLkdP7DQpJ3D3jJagQJugziThcqZCJVUT0HABHJt9EQMiiuf93KcUV/MMoisl56UfCxCFfmWQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -414,12 +436,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -475,12 +497,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -537,12 +559,12 @@
       }
     },
     "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -607,12 +629,12 @@
       }
     },
     "node_modules/@aws-sdk/client-firehose/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -672,12 +694,12 @@
       }
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -733,12 +755,12 @@
       }
     },
     "node_modules/@aws-sdk/client-lex-runtime-service/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -748,6 +770,580 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-lex-runtime-service/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@aws-sdk/client-location": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.22.0.tgz",
+      "integrity": "sha512-1DOpMgEtln581fo2rYjDpgsKE5ScpFBPwbZKYDjiPo8qF3Rcl/LKI7HLgmeCDQBWobvOtnKB8+9bZVpqx1rEUA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.1.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-sdk/client-sts": "3.22.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+      "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+      "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+      "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+      "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+      "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+      "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-ini": "3.22.0",
+        "@aws-sdk/credential-provider-process": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+      "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+      "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/hash-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+      "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+      "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+      "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+      "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+      "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+      "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/service-error-classification": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+      "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+      "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+      "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+      "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+      "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+      "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+      "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+      "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+      "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+      "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/url-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+      "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+      "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+      "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+      "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+      "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+      "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+      "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+      "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+      "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+      "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
@@ -794,12 +1390,12 @@
       }
     },
     "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -855,12 +1451,12 @@
       }
     },
     "node_modules/@aws-sdk/client-pinpoint/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -916,12 +1512,12 @@
       }
     },
     "node_modules/@aws-sdk/client-polly/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -978,12 +1574,12 @@
       }
     },
     "node_modules/@aws-sdk/client-rekognition/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -1054,12 +1650,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -1069,6 +1665,1070 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.22.0.tgz",
+      "integrity": "sha512-LXskY6Mvo/wk2dL1FNTazzhWiHiI3+nJdAT7iNOAg2Q1EUGVAfK+6EccEFPqaBtJDN4kv047HxXNVXKxJSyICg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+      "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+      "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+      "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/hash-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+      "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+      "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+      "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+      "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+      "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+      "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/service-error-classification": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+      "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+      "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+      "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+      "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+      "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+      "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+      "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+      "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+      "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/url-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+      "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+      "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+      "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+      "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+      "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+      "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+      "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+      "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+      "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+      "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.22.0.tgz",
+      "integrity": "sha512-3htpVHnnD4AvHPo+8VfkPbegN4WPAqcNIXPKCMNkNbYmnLLbtB4MlzKsRgpBP4LvRhi/2kt8fapRTQuTXo/8Mg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-sdk-sts": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+      "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+      "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+      "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+      "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+      "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+      "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-ini": "3.22.0",
+        "@aws-sdk/credential-provider-process": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+      "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+      "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/hash-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+      "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+      "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+      "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+      "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+      "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+      "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/service-error-classification": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+      "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+      "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+      "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+      "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+      "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+      "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+      "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+      "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+      "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+      "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/url-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+      "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+      "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+      "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+      "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+      "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+      "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+      "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+      "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+      "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+      "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
@@ -1115,12 +2775,12 @@
       }
     },
     "node_modules/@aws-sdk/client-textract/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -1177,12 +2837,12 @@
       }
     },
     "node_modules/@aws-sdk/client-translate/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -1304,6 +2964,96 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.22.0.tgz",
+      "integrity": "sha512-lgqvFIJctJmD2kjWY/BjXdKhH2Fndj/8CPRTDs8ja9AOXU/C3ExnDA15vqhDm5JvKmlkafQEtmypg5n+AZCwSw==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.22.0.tgz",
+      "integrity": "sha512-4CTVRuh3EMbH+EYtY0balZ+05BvjcTcW+n0uISK4a4KSMvVBWbhmiIm3U5ducPZfKAenf2mS0UHYRmV/nRLJzA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/eventstream-marshaller": {
       "version": "3.6.1",
@@ -1569,15 +3319,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/@react-native-community/cli": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.0.0.tgz",
-      "integrity": "sha512-wTbdpai58WzUBrw8lNbF/cSzX3pOWz+y+d46ip3M3Abd5yHNRvhuejRMVQC1o9luOM+ESJa4imYSbVdh7y5g+w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
+      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.0.0",
-        "@react-native-community/cli-server-api": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-hermes": "^6.1.0",
+        "@react-native-community/cli-plugin-metro": "^6.1.0",
+        "@react-native-community/cli-server-api": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "@react-native-community/cli-types": "^6.0.0",
         "appdirsjs": "^1.2.4",
         "chalk": "^3.0.0",
@@ -1594,12 +3345,6 @@
         "joi": "^17.2.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
-        "metro": "^0.66.1",
-        "metro-config": "^0.66.1",
-        "metro-core": "^0.66.1",
-        "metro-react-native-babel-transformer": "^0.66.1",
-        "metro-resolver": "^0.66.1",
-        "metro-runtime": "^0.66.1",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
         "node-stream-zip": "^1.9.1",
@@ -1619,7 +3364,7 @@
         "node": ">=12"
       },
       "peerDependencies": {
-        "react-native": ">=0.65.0-rc.0 || 0.0.0-*"
+        "react-native": "*"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/ansi-regex": {
@@ -1801,9 +3546,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/react-native": {
-      "version": "0.65.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.65.1.tgz",
-      "integrity": "sha512-0UOVSnlssweQZjuaUtzViCifE/4tXm8oRbxwakopc8GavPu9vLulde145GOw6QVYiOy4iL50f+2XXRdX9NmMeQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.0.tgz",
+      "integrity": "sha512-m26TKwzsfHVdZ1hDG+7mZ4M4ftxFFZrhtiT0OXuwfBzmNtB3xhsJtYszPeizw33c9YNp8rvehKT3c4ldDCW6kA==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
@@ -1812,12 +3557,12 @@
         "@react-native-community/cli-platform-ios": "^6.0.0",
         "@react-native/assets": "1.0.0",
         "@react-native/normalize-color": "1.0.0",
-        "@react-native/polyfills": "1.0.0",
+        "@react-native/polyfills": "2.0.0",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "base64-js": "^1.1.2",
         "event-target-shim": "^5.0.1",
-        "hermes-engine": "~0.8.1",
+        "hermes-engine": "~0.9.0",
         "invariant": "^2.2.4",
         "jsc-android": "^250230.2.1",
         "metro-babel-register": "0.66.2",
@@ -1828,7 +3573,8 @@
         "pretty-format": "^26.5.2",
         "promise": "^8.0.3",
         "prop-types": "^15.7.2",
-        "react-devtools-core": "^4.6.0",
+        "react-devtools-core": "^4.13.0",
+        "react-native-codegen": "^0.0.7",
         "react-refresh": "^0.4.0",
         "regenerator-runtime": "^0.13.2",
         "scheduler": "^0.20.2",
@@ -1950,6 +3696,122 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.22.0.tgz",
+      "integrity": "sha512-CpfPpKTKEcxyooDwa7tFZDhhB3RwByxwzQ+jEAUcDvSLRALyNb1jvwAfgJJQBx6uZgqj97Z46UYpMJIDoCebTA==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+      "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/middleware-serde": {
       "version": "3.6.1",
@@ -2263,6 +4125,34 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-credentials": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.22.0.tgz",
+      "integrity": "sha512-PI4aYgYgLIM8m2zNxXCK/GDlcHUX2akN1QKshM7uPhp5ZsjXVpR//FQ9DsRp+gKFk8VN+4zGo3eIIuJOAVEe3Q==",
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-credentials/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-credentials/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/@aws-sdk/util-format-url": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.6.1.tgz",
@@ -2288,9 +4178,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.29.0.tgz",
-      "integrity": "sha512-gvcbl9UdTOvuCCzgbtTTsKnL1l/cnT/CFl0f6ZCQ6qubUTRCuL/aK8DvgWa1n9p/ddCiVKPLmHu/L1xtX4gc0A==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.34.0.tgz",
+      "integrity": "sha512-/xZs6dJ+00H/vNi4+tRoj32XfkhDCYWiASI/wVMzpZG/F15SOipe9MWxUWrH7FAm+BSp5cHcdnLtzFoJmI5cCQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2683,9 +4573,12 @@
       "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-wrap-function": {
       "version": "7.13.0",
@@ -3098,11 +4991,14 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.13.tgz",
-      "integrity": "sha512-J/RYxnlSLXZLVR7wTRsozxKT8qbsx1mNKJzXEEjQ0Kjx1ZACcyHgbanNWNCFtc36IzuWhYWPpvJFFoexoOWFmA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -3856,6 +5752,39 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
+      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-flow/node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
+      "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-flow": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
@@ -4246,21 +6175,21 @@
       }
     },
     "node_modules/@jest/create-cache-key-function": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.2.0.tgz",
-      "integrity": "sha512-o+Q6CAT/mPNxiOGn6+UD/buY8O5cyDHbjD8FXDCUZbzfCwt6zYlmCMObLE+k1i/XJc5M3YIvEeaa6L7x7uAeYQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.2.4.tgz",
+      "integrity": "sha512-Cd9A6ugtkkHiQHDNbifdFrBBTgsKHp1KgCAjyAGMCrxFudR2icTKIPkXN2R2/IoMAMObUidMRBLDJy/RgX7uDQ==",
       "peer": true,
       "dependencies": {
-        "@jest/types": "^27.1.1"
+        "@jest/types": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/create-cache-key-function/node_modules/@jest/types": {
-      "version": "27.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
-      "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+      "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
       "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4669,13 +6598,13 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.0.0.tgz",
-      "integrity": "sha512-YUX8MEmDsEYdFuo/juCZUUDPPRQ/su3K/SPcSVmv7AIAwO/7ItuQ7+58PRI914XNvnRmY1GNVHKfWhUoNXMxvA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
+      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-platform-android": "^6.0.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-platform-android": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
@@ -4695,12 +6624,12 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.0.0.tgz",
-      "integrity": "sha512-yXyrM2elKM8/thf1d8EMMm0l0KdeWmIMhWZzCoRpCIQoUuVtiCEMyrZF+aufvNvy74soKiCFeAmGNI8LPk2hzg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
+      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
@@ -4795,12 +6724,12 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.0.0.tgz",
-      "integrity": "sha512-+f6X4jDGuPpVcY2NsVAstnId4stnG7EvzLUhs7FUpMFjzss9c1ZJhsqQeKikOtzZbwLzFrpki/QrTK79ur7xSg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
+      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
@@ -4822,14 +6751,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/@react-native-community/cli-plugin-metro": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
+      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "peer": true,
+      "dependencies": {
+        "@react-native-community/cli-server-api": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
+        "chalk": "^3.0.0",
+        "metro": "^0.66.1",
+        "metro-config": "^0.66.1",
+        "metro-core": "^0.66.1",
+        "metro-react-native-babel-transformer": "^0.66.1",
+        "metro-resolver": "^0.66.1",
+        "metro-runtime": "^0.66.1",
+        "mkdirp": "^0.5.1",
+        "readline": "^1.3.0"
+      }
+    },
+    "node_modules/@react-native-community/cli-plugin-metro/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.0.0-rc.0.tgz",
-      "integrity": "sha512-shPG9RXXpDYeluoB3tzaYU9Ut0jTvZ3osatLLUJkWjbRjFreK9zUcnoFDDrsVT6fEoyeBftp5DSa+wCUnPmcJA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
+      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -4850,16 +6811,19 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.0.0-rc.0.tgz",
-      "integrity": "sha512-N31BhNacTe0UGYQxUx0WHWPKnF4pBe62hNRV9WNJdWqVl4TP45T1Fd/7ziiosfalIar+tOo9Sk0Pqq48x1+wNw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
+      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
       "peer": true,
       "dependencies": {
+        "appdirsjs": "^1.2.4",
         "chalk": "^3.0.0",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
+        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
+        "semver": "^6.3.0",
         "shell-quote": "1.6.1"
       }
     },
@@ -4900,6 +6864,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@react-native-community/cli-tools/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@react-native-community/cli-tools/node_modules/shell-quote": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
@@ -4934,9 +6907,9 @@
       "peer": true
     },
     "node_modules/@react-native/polyfills": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-1.0.0.tgz",
-      "integrity": "sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
+      "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
       "peer": true
     },
     "node_modules/@restart/context": {
@@ -5025,9 +6998,9 @@
       }
     },
     "node_modules/@sideway/address/node_modules/@hapi/hoek": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
       "peer": true
     },
     "node_modules/@sideway/formula": {
@@ -6476,9 +8449,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "node_modules/amazon-cognito-identity-js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.1.0.tgz",
-      "integrity": "sha512-zGJo9jpTBHaTrir9nBWxMnteR+uPMSq3SO9AT0EOAO/e1CyJ27sawe0Pd3218HPzsooOMZt0iYaWkpVrsQ3nSQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.0.tgz",
+      "integrity": "sha512-7nRkGb9Cinf1rD5t34B0NDWXO7lmyapXzLmSXq4IBOdiBMrmxToEHcRwfwT2jJfBWzzZiOS0gvQhKI32A+rmvg==",
       "dependencies": {
         "buffer": "4.9.2",
         "crypto-js": "^4.1.1",
@@ -6629,9 +8602,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
       }
@@ -6884,10 +8857,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+    },
+    "node_modules/ast-types/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "peer": true
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -6961,22 +8952,23 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.2.9.tgz",
-      "integrity": "sha512-kMbXfgmcTjN3KLsMYAGBe7iy8Ih1/3Den5ZPEvEg7YTlkgtQ7YguyltdekE/yHV5JCCKTB8G1D2wmsvfHkid5w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.1.tgz",
+      "integrity": "sha512-dvBVTDbpMfS91E0b9qxltIALTCP3b2pQpTyVQxUa9tuevEsi4YFL7EDcvQF4ScJkNwnuoTKVJsNCjrq8SJCJMg==",
       "dependencies": {
-        "@aws-amplify/analytics": "5.0.15",
-        "@aws-amplify/api": "4.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/datastore": "3.4.3",
-        "@aws-amplify/interactions": "4.0.15",
-        "@aws-amplify/predictions": "4.0.15",
-        "@aws-amplify/pubsub": "4.1.7",
-        "@aws-amplify/storage": "4.3.10",
+        "@aws-amplify/analytics": "5.0.19",
+        "@aws-amplify/api": "4.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/datastore": "3.4.7",
+        "@aws-amplify/geo": "1.1.1",
+        "@aws-amplify/interactions": "4.0.19",
+        "@aws-amplify/predictions": "4.0.19",
+        "@aws-amplify/pubsub": "4.1.11",
+        "@aws-amplify/storage": "4.4.2",
         "@aws-amplify/ui": "2.0.3",
-        "@aws-amplify/xr": "3.0.15"
+        "@aws-amplify/xr": "3.0.19"
       }
     },
     "node_modules/axe-core": {
@@ -6999,6 +8991,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+    },
+    "node_modules/babel-core": {
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "peer": true,
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
     },
     "node_modules/babel-eslint": {
       "version": "10.1.0",
@@ -7644,9 +9645,9 @@
       }
     },
     "node_modules/big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "version": "1.6.49",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
+      "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
       "peer": true,
       "engines": {
         "node": ">=0.6"
@@ -8151,6 +10152,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -8401,9 +10426,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -8636,6 +10661,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -9937,12 +11971,29 @@
       }
     },
     "node_modules/domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
       "dependencies": {
-        "domelementtype": "1"
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/domhandler/node_modules/domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -11587,11 +13638,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.20.0.tgz",
-      "integrity": "sha512-cMQwDJYVDjMPU56DviszewgMKuNzuf4NQSBuDf9RgZ6FKm5QEMxW05Za8lvnuL6moxoeZVUWBlL733WmovvV6g==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.20.3.tgz",
+      "integrity": "sha512-FfHJ/QCpo4K2gquBX7dIAcmShSBG4dMtYJ3ghSiR4w7YqlUujuamrM57C+mKLNWS3mvZzmm2B2Qx8Q6Gfw+lDQ==",
       "dependencies": {
-        "strnum": "^1.0.3"
+        "strnum": "^1.0.4"
       },
       "bin": {
         "xml2js": "cli.js"
@@ -11876,6 +13927,15 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
       "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash."
+    },
+    "node_modules/flow-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
+      "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
@@ -12597,9 +14657,9 @@
       }
     },
     "node_modules/hermes-engine": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.8.1.tgz",
-      "integrity": "sha512-as9Iccj/qrqqtDmfYUHbOIjt5xsQbUB6pjNIW3i1+RVr+pCAdz5S8/Jry778mz3rJWplYzHWdR1u1xQSYfBRYw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.9.0.tgz",
+      "integrity": "sha512-r7U+Y4P2Qg/igFVZN+DpT7JFfXUn1MM4dFne8aW+cCrF6RRymof+VqrUHs1kl07j8h8V2CNesU19RKgWbr3qPw==",
       "peer": true
     },
     "node_modules/hermes-parser": {
@@ -12766,34 +14826,58 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
       "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
       }
     },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-    },
-    "node_modules/htmlparser2/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
       },
-      "engines": {
-        "node": ">= 6"
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/http-deceiver": {
@@ -15234,9 +17318,9 @@
       }
     },
     "node_modules/joi/node_modules/@hapi/hoek": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
       "peer": true
     },
     "node_modules/joi/node_modules/@hapi/topo": {
@@ -15275,6 +17359,169 @@
       "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-250230.2.1.tgz",
       "integrity": "sha512-KmxeBlRjwoqCnBBKGsihFtvsBHyUFlBxJPK4FzeYcIuBfdjv6jFys44JITAgSTbQD+vIdwMEfyZklsuQX0yI1Q==",
       "peer": true
+    },
+    "node_modules/jscodeshift": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.11.0.tgz",
+      "integrity": "sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.1.6",
+        "@babel/parser": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.1.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/preset-flow": "^7.0.0",
+        "@babel/preset-typescript": "^7.1.0",
+        "@babel/register": "^7.0.0",
+        "babel-core": "^7.0.0-bridge.0",
+        "colors": "^1.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^3.1.10",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.20.3",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^2.3.0"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "peer": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "peer": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "peer": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "peer": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "peer": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "peer": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "peer": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "peer": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jsdom": {
       "version": "16.6.0",
@@ -15917,6 +18164,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -16538,6 +18796,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/metro/node_modules/temp": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "engines": [
+        "node >=0.8.0"
+      ],
+      "peer": true,
+      "dependencies": {
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
+      }
+    },
+    "node_modules/metro/node_modules/temp/node_modules/rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "peer": true,
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/metro/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -17011,6 +19291,18 @@
       "peer": true,
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.5"
       }
     },
     "node_modules/node-fetch": {
@@ -19810,6 +22102,14 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -20158,9 +22458,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.18.0.tgz",
-      "integrity": "sha512-Kg/LhDkdt9J0ned1D1RfeuSdX4cKW83/valJLYswGdsYc0g2msmD0kfYozsaRacjDoZwcKlxGOES1wrkET5O6Q==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.19.1.tgz",
+      "integrity": "sha512-2wJiGffPWK0KggBjVwnTaAk+Z3MSxKInHmdzPTrBh1mAarexsa93Kw+WMX88+XjN+TtYgAiLe9xeTqcO5FfJTw==",
       "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -20210,6 +22510,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-native-codegen": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.0.7.tgz",
+      "integrity": "sha512-dwNgR8zJ3ALr480QnAmpTiqvFo+rDtq6V5oCggKhYFlRjzOmVSFn3YD41u8ltvKS5G2nQ8gCs2vReFFnRGLYng==",
+      "peer": true,
+      "dependencies": {
+        "flow-parser": "^0.121.0",
+        "jscodeshift": "^0.11.0",
+        "nullthrows": "^1.1.1"
+      }
     },
     "node_modules/react-overlays": {
       "version": "5.0.1",
@@ -20540,6 +22851,33 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=",
+      "peer": true
+    },
+    "node_modules/recast": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "peer": true,
+      "dependencies": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "peer": true
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -20689,15 +23027,15 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "node_modules/renderkid": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.5.tgz",
-      "integrity": "sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
       "dependencies": {
-        "css-select": "^2.0.2",
-        "dom-converter": "^0.2",
-        "htmlparser2": "^3.10.1",
-        "lodash": "^4.17.20",
-        "strip-ansi": "^3.0.0"
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^3.0.1"
       }
     },
     "node_modules/renderkid/node_modules/ansi-regex": {
@@ -20706,6 +23044,80 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/renderkid/node_modules/css-select": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
+        "nth-check": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/renderkid/node_modules/css-what": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/renderkid/node_modules/dom-serializer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/renderkid/node_modules/domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/renderkid/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/renderkid/node_modules/nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/renderkid/node_modules/strip-ansi": {
@@ -22526,9 +24938,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.3.tgz",
-      "integrity": "sha512-GVoRjsqAYZkAH16GDzfTuafuwKxzKdaaCQyLaWf37gOP1e2PPbAKWoME1OmO+c4RCKMfNrrPRDLFCNBFU45N/A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.4.tgz",
+      "integrity": "sha512-lMzNMfDpaQOLt4B2mEbfzYS0+T7dvCXeojnlGf6f1AygvWDMcWyXYaLbyICfjVu29sErR8fnRagQfBW/N/hGgw=="
     },
     "node_modules/style-loader": {
       "version": "1.3.0",
@@ -22768,16 +25180,15 @@
       }
     },
     "node_modules/temp": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-      "engines": [
-        "node >=0.8.0"
-      ],
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
       "peer": true,
       "dependencies": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/temp-dir": {
@@ -22789,10 +25200,13 @@
       }
     },
     "node_modules/temp/node_modules/rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
       "bin": {
         "rimraf": "bin.js"
       }
@@ -23043,9 +25457,9 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "node_modules/to-arraybuffer": {
       "version": "1.0.1",
@@ -25389,6 +27803,17 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
@@ -25648,12 +28073,12 @@
   },
   "dependencies": {
     "@aws-amplify/analytics": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.0.15.tgz",
-      "integrity": "sha512-AP++UPU/rmXJ6Z+id5WBDSR4ioMkMYlPDlBZl0zIl67Om+J4G3Q0zJ6Q5ft6oZOkGotw+7smI3hBRSBoeF6kxg==",
+      "version": "5.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.0.19.tgz",
+      "integrity": "sha512-TDnDOTjb1gZ9ASs8JyiejVB8nIU79BMq5CSEsuBDOg7WpM5zeIRC5dXpdfw2e92w5W+ACr9vTKwmgv8c2JYeow==",
       "requires": {
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-firehose": "3.6.1",
         "@aws-sdk/client-kinesis": "3.6.1",
         "@aws-sdk/client-personalize-events": "3.6.1",
@@ -25671,24 +28096,24 @@
       }
     },
     "@aws-amplify/api": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.15.tgz",
-      "integrity": "sha512-GTm8d5PLstQxwYA+b7OPBCMarc4Nwp4A5VFxYsXHI63fOShXhqCX9Le6Ivnk0X1Vcg9hrtips//qkRFjOQyEiw==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.19.tgz",
+      "integrity": "sha512-+bP1sSAkRlbId/cCBYrPkaqybvOBRK8ldolr5CH5pWhWKGWO0FsjDRMu7gQI4wKGDk3NdmB40XUa+abT2jPz2g==",
       "requires": {
-        "@aws-amplify/api-graphql": "2.2.4",
-        "@aws-amplify/api-rest": "2.0.15"
+        "@aws-amplify/api-graphql": "2.2.8",
+        "@aws-amplify/api-rest": "2.0.19"
       }
     },
     "@aws-amplify/api-graphql": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.4.tgz",
-      "integrity": "sha512-ZNeOe6p8GGAPN7A1wDTfwRyfJUlMraB0K/dAUiUqb8pPmdaqq9YYbAmJ9h+7itDZ5/gahGeByx8CAhomylwwsA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.8.tgz",
+      "integrity": "sha512-FMwUUNkK/WU6xCRfxDuxGZPay+Lbiz6i4rvD7mfUfeCc7zN8sZa832Buu+0CwYhlC75PlQOeU23UARDwWcConQ==",
       "requires": {
-        "@aws-amplify/api-rest": "2.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/pubsub": "4.1.7",
+        "@aws-amplify/api-rest": "2.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/pubsub": "4.1.11",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
@@ -25702,37 +28127,37 @@
       }
     },
     "@aws-amplify/api-rest": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.15.tgz",
-      "integrity": "sha512-jGPwdV2egaIoxV5sHR9UcjQtloE8hf6/ZavZdDSlOSmfztC20kfK5y+UibYdZdD4DroTrKkSlkRt9XiaXLq1tw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.19.tgz",
+      "integrity": "sha512-FvEV/nX5beeD0zHTvwIcCrrgSfWymhvvrcDX7L5RPoitv415sruXcbj0e6ODCAm0Aw2bieW2K2fXIQ1gNa0JtQ==",
       "requires": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
         "axios": "0.21.4"
       }
     },
     "@aws-amplify/auth": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.5.tgz",
-      "integrity": "sha512-EhlpiMh3yIMR0Df79TQqp0z37gKpHAp1+QBRmwp0NSDAM8JMpGwt/rb7+WGyEMLVVhMMb24YuE75UshhNegQcQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.9.tgz",
+      "integrity": "sha512-E61GTg9GaHAsC5NrRqD1JGMHWvyWKeMjD8Cjt9kZEwQq7Y33oP9KJ7vUinSpGi2Eh2pnJSXg5z23Xx8BGVZeag==",
       "requires": {
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "amazon-cognito-identity-js": "5.1.0",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "amazon-cognito-identity-js": "5.2.0",
         "crypto-js": "^4.1.1"
       }
     },
     "@aws-amplify/cache": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.17.tgz",
-      "integrity": "sha512-I+ND9ZU65dZXIT0VR+du7qZTq61vdFJdL5uhNCh7XQATJCqJtulH86csMpfJ6gosQM3+pcg4rEPQSgDnqPaE3w==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.21.tgz",
+      "integrity": "sha512-tJK9ShFq4LJgOGrGI3ilr0bxrNLXLmmAsRpPwfqyQvKG7ZyUI9r8K5sQi8ov8QIhr/ogoDpQOeWcN5Fhp3Gj2A==",
       "requires": {
-        "@aws-amplify/core": "4.2.9"
+        "@aws-amplify/core": "4.3.1"
       }
     },
     "@aws-amplify/core": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.2.9.tgz",
-      "integrity": "sha512-a5xSu1fOQNxgpQsfuUkJbzRBkoD+JcasdfMpXGcgYr1Iuj5Sua4xcLe4Z9O4VaGaUy1Y7laHDP4aa+Mn/RJq9w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.3.1.tgz",
+      "integrity": "sha512-qYQIs95F/AdBGbUFNXzKp3nAFPpQtivvBGOFQa+plqK/mzV23fh33BxRh/Hc3A+bcfpM8lBDZbIn9LPVRj3VLA==",
       "requires": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
         "@aws-sdk/client-cloudwatch-logs": "3.6.1",
@@ -25745,15 +28170,15 @@
       }
     },
     "@aws-amplify/datastore": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.3.tgz",
-      "integrity": "sha512-XgjyzOX6bY+zAsv/ylvX0aeElZfbpzq0X8bw9Zx1zrb9wIGOYfSjDC3HzeffoGkFBb/lOscFvN1jbAsxQygWsw==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.7.tgz",
+      "integrity": "sha512-UB9CdZCC397Gl3G8neIxTx86JSFL27ftMNIKPrYTvWQEF2sKy5zP7Kr572pW60I5cw7+FERlH3BJ+SIbzYcuKg==",
       "requires": {
-        "@aws-amplify/api": "4.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/pubsub": "4.1.7",
-        "amazon-cognito-identity-js": "5.1.0",
+        "@aws-amplify/api": "4.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/pubsub": "4.1.11",
+        "amazon-cognito-identity-js": "5.2.0",
         "idb": "5.0.6",
         "immer": "9.0.6",
         "ulid": "2.3.0",
@@ -25774,22 +28199,32 @@
         }
       }
     },
-    "@aws-amplify/interactions": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.15.tgz",
-      "integrity": "sha512-OaLAGzu/gu2GNDZLX41i1bT67eEnBJiyyS/eh5c3skrFvYI3zyjAEzD3cIsOVU2LwhnLZRMNSwoXNqAlkFbtHQ==",
+    "@aws-amplify/geo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-1.1.1.tgz",
+      "integrity": "sha512-sasyp6l+/ZMXcCVWaKyEZiV7hGGzTQV9D3dbU1iqi6/BHEFRfJxnubt3P39XaR672SQ1e8qhFDx36TiL5mePcA==",
       "requires": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-sdk/client-location": "3.22.0",
+        "camelcase-keys": "6.2.2"
+      }
+    },
+    "@aws-amplify/interactions": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.19.tgz",
+      "integrity": "sha512-g33BUZbMkI6Qkwa9KyCCHMaoUmprY8XVJRVuamVo6+3qCMZXn5KDXa/cTad7+NCASDzMo/XWb65vmWeo9hyw8Q==",
+      "requires": {
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-lex-runtime-service": "3.6.1"
       }
     },
     "@aws-amplify/predictions": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.15.tgz",
-      "integrity": "sha512-bfsWlRd6ZyV5PbqSohpug9KzW5GR82K2UdFU+s90UPCHuj78eSFLflttl/ako95u7tFFFq4MUWtC+rWX5+miMQ==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.19.tgz",
+      "integrity": "sha512-bHT7gYECVLkkcenQ8filTqeDndx+PrV1MlncYfgsaZp0xjnZ4WaQsvIvSf+ZUvQxk3ayzn85p0MRwPKJR4yEqQ==",
       "requires": {
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/storage": "4.3.10",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/storage": "4.4.2",
         "@aws-sdk/client-comprehend": "3.6.1",
         "@aws-sdk/client-polly": "3.6.1",
         "@aws-sdk/client-rekognition": "3.6.1",
@@ -25808,13 +28243,13 @@
       }
     },
     "@aws-amplify/pubsub": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.7.tgz",
-      "integrity": "sha512-ES9E4utrsers96bHl1E7clKZanlH9modcjjovJPswLi85q0tybTAG+fi9QRYHp07XSN+EjmEF4Jxrw47w4Hmzw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.11.tgz",
+      "integrity": "sha512-Z7xZ244LY6sIK2i6NIBkhuZGXhcVPLFLhyZc1adACuxDWPnZo0Xtiu6SWdZ1Sf575iHRHBCg6DG6TWf8m1YpaA==",
       "requires": {
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
         "graphql": "14.0.0",
         "paho-mqtt": "^1.1.0",
         "uuid": "^3.2.1",
@@ -25829,11 +28264,11 @@
       }
     },
     "@aws-amplify/storage": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.3.10.tgz",
-      "integrity": "sha512-Mplgkd+mmWxoB7P4m+0UK++Nb+97eeH7/ZKemLIFL8s8N1n2voQZJLK9uTkY3vvIS17sT9QvWCMl63v6TPnebw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.4.2.tgz",
+      "integrity": "sha512-BjdDq+PcKCS7taMcwc3moKEIykw0vfgzKBClSBBwyXP5ewHQJNYMhe7sGlVt17MyFBTQkBVWJtt9QsvcNcw98w==",
       "requires": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-s3": "3.6.1",
         "@aws-sdk/s3-request-presigner": "3.6.1",
         "@aws-sdk/util-create-request": "3.6.1",
@@ -25849,35 +28284,37 @@
       "integrity": "sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A=="
     },
     "@aws-amplify/ui-components": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-1.7.8.tgz",
-      "integrity": "sha512-BR31SXO5ppyhhOkw+Qys2sSkDV0rjHDO/5NAkJwP9OhOm47QgIIaKCdTurIYnaskelMflKgetVAts+2xUymegg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-1.8.2.tgz",
+      "integrity": "sha512-w+iJh66itkpZ13MSmIL0LW5frrk4dP9FdcH5KvGAgUDjLSM4dOqeBa1wuPHHJ5pkilByZMK9LHkqP7TIAMdWdA==",
       "requires": {
         "qrcode": "^1.4.4",
         "uuid": "^8.2.0"
       }
     },
     "@aws-amplify/ui-react": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.15.tgz",
-      "integrity": "sha512-baBOFmJiuqiaeEZaT/TW2ZjxcsdciwiCTFC2qaOXJHMNAYyUzMXY7mOHeaNblBrI+uzppm4dvjVPqmB8zcjr7A==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.19.tgz",
+      "integrity": "sha512-qf+XZujT/i8eNHgV7P5P2UGCTzJldrgYCdSW15jSJhPSZ3iJNvHjVbeB7FAdIIm2hH65/WJkF2kixsf5G6rwEQ==",
       "requires": {
-        "@aws-amplify/ui-components": "1.7.8"
+        "@aws-amplify/ui-components": "1.8.2"
       }
     },
     "@aws-amplify/xr": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.15.tgz",
-      "integrity": "sha512-sINduNuGaPjeyZ/9iDbzevHyNWiHRHYeDVfzbgNFE8lf92uqN3m1rN8acg7wJHjnaDpw/0qFPGzN/tT+s/SvDg==",
+      "version": "3.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.19.tgz",
+      "integrity": "sha512-wogJDDVLXrDribhhW/OUK8ZTqFAmVuDHn8O/tusBOdpnjfYULddDML6BSBtYMsP3TGkOz7c7v/HPTtWBfRR2ZQ==",
       "requires": {
-        "@aws-amplify/core": "4.2.9"
+        "@aws-amplify/core": "4.3.1"
       }
     },
     "@aws-crypto/crc32": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.1.0.tgz",
-      "integrity": "sha512-ifvfaaJVvT+JUTi3zSkX4wtuGGVJrAcjN7ftg+JiE/frNBP3zNwo4xipzWBsMLZfNuzMZuaesEYyqkZcs5tzCQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.2.1.tgz",
+      "integrity": "sha512-Ydso55lIn3Vudui5jXNKcxmyVr9BNWeIkAhleGuG9zpb0Pu5yXf2Jth2A07fUyLSXX2gwfv0d84zwvKK2FMbuA==",
       "requires": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
         "tslib": "^1.11.1"
       }
     },
@@ -25890,26 +28327,26 @@
       }
     },
     "@aws-crypto/sha256-browser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.1.tgz",
-      "integrity": "sha512-nS4vdan97It6HcweV58WXtjPbPSc0JXd3sAwlw3Ou5Mc3WllSycAS32Tv2LRn8butNQoU9AE3jEQAOgiMdNC1Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.1.tgz",
+      "integrity": "sha512-WX/Wp6sXPhcBWx/w1aSJv3bDJL0ut5Ik6hl7yfqA1pn3cfsahl4rgHzRRXqYfJ+hnhnCqdgadS17wyBbVPsK+w==",
       "requires": {
         "@aws-crypto/ie11-detection": "^1.0.0",
-        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/sha256-js": "^1.2.1",
         "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           }
         }
@@ -25945,6 +28382,16 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
       "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.1.tgz",
+      "integrity": "sha512-H6Qrl28lzGGXZgLkdP7DQpJ3D3jJagQJugziThcqZCJVUT0HABHJt9EQMiiuf93KcUV/MMoisl56UfCxCFfmWQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -26013,12 +28460,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26075,12 +28522,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26138,12 +28585,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26205,12 +28652,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26271,12 +28718,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26333,12 +28780,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26347,6 +28794,476 @@
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/client-location": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.22.0.tgz",
+      "integrity": "sha512-1DOpMgEtln581fo2rYjDpgsKE5ScpFBPwbZKYDjiPo8qF3Rcl/LKI7HLgmeCDQBWobvOtnKB8+9bZVpqx1rEUA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.1.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-sdk/client-sts": "3.22.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.1",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+          "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+          "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+          "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+          "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+          "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+          "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-ini": "3.22.0",
+            "@aws-sdk/credential-provider-process": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+          "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+          "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+          "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+          "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+          "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+          "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+          "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+          "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/service-error-classification": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+          "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+          "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+          "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+          "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+          "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+          "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+          "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+          "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+          "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+          "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+          "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+          "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+          "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+          "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+          "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+          "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+          "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+          "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+          "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
           }
         },
         "tslib": {
@@ -26395,12 +29312,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26457,12 +29374,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26519,12 +29436,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26582,12 +29499,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26659,12 +29576,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26674,6 +29591,873 @@
               "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
           }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.22.0.tgz",
+      "integrity": "sha512-LXskY6Mvo/wk2dL1FNTazzhWiHiI3+nJdAT7iNOAg2Q1EUGVAfK+6EccEFPqaBtJDN4kv047HxXNVXKxJSyICg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.1",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+          "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+          "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+          "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+          "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+          "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+          "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+          "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+          "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+          "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/service-error-classification": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+          "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+          "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+          "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+          "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+          "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+          "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+          "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+          "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+          "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+          "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+          "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+          "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+          "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+          "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+          "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+          "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+          "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+          "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.22.0.tgz",
+      "integrity": "sha512-3htpVHnnD4AvHPo+8VfkPbegN4WPAqcNIXPKCMNkNbYmnLLbtB4MlzKsRgpBP4LvRhi/2kt8fapRTQuTXo/8Mg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-sdk-sts": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.1",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+          "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+          "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+          "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+          "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+          "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+          "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-ini": "3.22.0",
+            "@aws-sdk/credential-provider-process": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+          "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+          "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+          "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+          "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+          "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+          "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+          "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+          "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/service-error-classification": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+          "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+          "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+          "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+          "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+          "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+          "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+          "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+          "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+          "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+          "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+          "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+          "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+          "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+          "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+          "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+          "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+          "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+          "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+          "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "3.19.0",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+          "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
         },
         "tslib": {
           "version": "2.3.1",
@@ -26721,12 +30505,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26784,12 +30568,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -26889,6 +30673,79 @@
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.22.0.tgz",
+      "integrity": "sha512-lgqvFIJctJmD2kjWY/BjXdKhH2Fndj/8CPRTDs8ja9AOXU/C3ExnDA15vqhDm5JvKmlkafQEtmypg5n+AZCwSw==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.22.0.tgz",
+      "integrity": "sha512-4CTVRuh3EMbH+EYtY0balZ+05BvjcTcW+n0uISK4a4KSMvVBWbhmiIm3U5ducPZfKAenf2mS0UHYRmV/nRLJzA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "@aws-sdk/eventstream-marshaller": {
@@ -27107,15 +30964,16 @@
       },
       "dependencies": {
         "@react-native-community/cli": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.0.0.tgz",
-          "integrity": "sha512-wTbdpai58WzUBrw8lNbF/cSzX3pOWz+y+d46ip3M3Abd5yHNRvhuejRMVQC1o9luOM+ESJa4imYSbVdh7y5g+w==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
+          "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
           "peer": true,
           "requires": {
             "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-            "@react-native-community/cli-hermes": "^6.0.0",
-            "@react-native-community/cli-server-api": "^6.0.0-rc.0",
-            "@react-native-community/cli-tools": "^6.0.0-rc.0",
+            "@react-native-community/cli-hermes": "^6.1.0",
+            "@react-native-community/cli-plugin-metro": "^6.1.0",
+            "@react-native-community/cli-server-api": "^6.1.0",
+            "@react-native-community/cli-tools": "^6.1.0",
             "@react-native-community/cli-types": "^6.0.0",
             "appdirsjs": "^1.2.4",
             "chalk": "^3.0.0",
@@ -27132,12 +30990,6 @@
             "joi": "^17.2.1",
             "leven": "^3.1.0",
             "lodash": "^4.17.15",
-            "metro": "^0.66.1",
-            "metro-config": "^0.66.1",
-            "metro-core": "^0.66.1",
-            "metro-react-native-babel-transformer": "^0.66.1",
-            "metro-resolver": "^0.66.1",
-            "metro-runtime": "^0.66.1",
             "minimist": "^1.2.0",
             "mkdirp": "^0.5.1",
             "node-stream-zip": "^1.9.1",
@@ -27296,9 +31148,9 @@
           }
         },
         "react-native": {
-          "version": "0.65.1",
-          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.65.1.tgz",
-          "integrity": "sha512-0UOVSnlssweQZjuaUtzViCifE/4tXm8oRbxwakopc8GavPu9vLulde145GOw6QVYiOy4iL50f+2XXRdX9NmMeQ==",
+          "version": "0.66.0",
+          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.0.tgz",
+          "integrity": "sha512-m26TKwzsfHVdZ1hDG+7mZ4M4ftxFFZrhtiT0OXuwfBzmNtB3xhsJtYszPeizw33c9YNp8rvehKT3c4ldDCW6kA==",
           "peer": true,
           "requires": {
             "@jest/create-cache-key-function": "^27.0.1",
@@ -27307,12 +31159,12 @@
             "@react-native-community/cli-platform-ios": "^6.0.0",
             "@react-native/assets": "1.0.0",
             "@react-native/normalize-color": "1.0.0",
-            "@react-native/polyfills": "1.0.0",
+            "@react-native/polyfills": "2.0.0",
             "abort-controller": "^3.0.0",
             "anser": "^1.4.9",
             "base64-js": "^1.1.2",
             "event-target-shim": "^5.0.1",
-            "hermes-engine": "~0.8.1",
+            "hermes-engine": "~0.9.0",
             "invariant": "^2.2.4",
             "jsc-android": "^250230.2.1",
             "metro-babel-register": "0.66.2",
@@ -27323,7 +31175,8 @@
             "pretty-format": "^26.5.2",
             "promise": "^8.0.3",
             "prop-types": "^15.7.2",
-            "react-devtools-core": "^4.6.0",
+            "react-devtools-core": "^4.13.0",
+            "react-native-codegen": "^0.0.7",
             "react-refresh": "^0.4.0",
             "regenerator-runtime": "^0.13.2",
             "scheduler": "^0.20.2",
@@ -27412,6 +31265,97 @@
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-arn-parser": "3.6.1",
         "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.22.0.tgz",
+      "integrity": "sha512-CpfPpKTKEcxyooDwa7tFZDhhB3RwByxwzQ+jEAUcDvSLRALyNb1jvwAfgJJQBx6uZgqj97Z46UYpMJIDoCebTA==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+          "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "@aws-sdk/middleware-serde": {
@@ -27657,6 +31601,30 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/util-credentials": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.22.0.tgz",
+      "integrity": "sha512-PI4aYgYgLIM8m2zNxXCK/GDlcHUX2akN1QKshM7uPhp5ZsjXVpR//FQ9DsRp+gKFk8VN+4zGo3eIIuJOAVEe3Q==",
+      "requires": {
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@aws-sdk/util-format-url": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.6.1.tgz",
@@ -27676,9 +31644,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.29.0.tgz",
-      "integrity": "sha512-gvcbl9UdTOvuCCzgbtTTsKnL1l/cnT/CFl0f6ZCQ6qubUTRCuL/aK8DvgWa1n9p/ddCiVKPLmHu/L1xtX4gc0A==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.34.0.tgz",
+      "integrity": "sha512-/xZs6dJ+00H/vNi4+tRoj32XfkhDCYWiASI/wVMzpZG/F15SOipe9MWxUWrH7FAm+BSp5cHcdnLtzFoJmI5cCQ==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -28026,9 +31994,9 @@
       "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.13.0",
@@ -28341,11 +32309,11 @@
       }
     },
     "@babel/plugin-syntax-flow": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.13.tgz",
-      "integrity": "sha512-J/RYxnlSLXZLVR7wTRsozxKT8qbsx1mNKJzXEEjQ0Kjx1ZACcyHgbanNWNCFtc36IzuWhYWPpvJFFoexoOWFmA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-syntax-import-meta": {
@@ -28921,6 +32889,29 @@
         }
       }
     },
+    "@babel/preset-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
+      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/plugin-transform-flow-strip-types": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
+          "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
+          "peer": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.14.5",
+            "@babel/plugin-syntax-flow": "^7.14.5"
+          }
+        }
+      }
+    },
     "@babel/preset-modules": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
@@ -29239,18 +33230,18 @@
       }
     },
     "@jest/create-cache-key-function": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.2.0.tgz",
-      "integrity": "sha512-o+Q6CAT/mPNxiOGn6+UD/buY8O5cyDHbjD8FXDCUZbzfCwt6zYlmCMObLE+k1i/XJc5M3YIvEeaa6L7x7uAeYQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.2.4.tgz",
+      "integrity": "sha512-Cd9A6ugtkkHiQHDNbifdFrBBTgsKHp1KgCAjyAGMCrxFudR2icTKIPkXN2R2/IoMAMObUidMRBLDJy/RgX7uDQ==",
       "peer": true,
       "requires": {
-        "@jest/types": "^27.1.1"
+        "@jest/types": "^27.2.4"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.1.1",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
-          "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
+          "version": "27.2.4",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+          "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
           "peer": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -29556,13 +33547,13 @@
       }
     },
     "@react-native-community/cli-hermes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.0.0.tgz",
-      "integrity": "sha512-YUX8MEmDsEYdFuo/juCZUUDPPRQ/su3K/SPcSVmv7AIAwO/7ItuQ7+58PRI914XNvnRmY1GNVHKfWhUoNXMxvA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
+      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-platform-android": "^6.0.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-platform-android": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
@@ -29581,12 +33572,12 @@
       }
     },
     "@react-native-community/cli-platform-android": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.0.0.tgz",
-      "integrity": "sha512-yXyrM2elKM8/thf1d8EMMm0l0KdeWmIMhWZzCoRpCIQoUuVtiCEMyrZF+aufvNvy74soKiCFeAmGNI8LPk2hzg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
+      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
@@ -29668,12 +33659,12 @@
       }
     },
     "@react-native-community/cli-platform-ios": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.0.0.tgz",
-      "integrity": "sha512-+f6X4jDGuPpVcY2NsVAstnId4stnG7EvzLUhs7FUpMFjzss9c1ZJhsqQeKikOtzZbwLzFrpki/QrTK79ur7xSg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
+      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
@@ -29694,14 +33685,45 @@
         }
       }
     },
+    "@react-native-community/cli-plugin-metro": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
+      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "peer": true,
+      "requires": {
+        "@react-native-community/cli-server-api": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
+        "chalk": "^3.0.0",
+        "metro": "^0.66.1",
+        "metro-config": "^0.66.1",
+        "metro-core": "^0.66.1",
+        "metro-react-native-babel-transformer": "^0.66.1",
+        "metro-resolver": "^0.66.1",
+        "metro-runtime": "^0.66.1",
+        "mkdirp": "^0.5.1",
+        "readline": "^1.3.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "@react-native-community/cli-server-api": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.0.0-rc.0.tgz",
-      "integrity": "sha512-shPG9RXXpDYeluoB3tzaYU9Ut0jTvZ3osatLLUJkWjbRjFreK9zUcnoFDDrsVT6fEoyeBftp5DSa+wCUnPmcJA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
+      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
       "peer": true,
       "requires": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -29724,16 +33746,19 @@
       }
     },
     "@react-native-community/cli-tools": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.0.0-rc.0.tgz",
-      "integrity": "sha512-N31BhNacTe0UGYQxUx0WHWPKnF4pBe62hNRV9WNJdWqVl4TP45T1Fd/7ziiosfalIar+tOo9Sk0Pqq48x1+wNw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
+      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
       "peer": true,
       "requires": {
+        "appdirsjs": "^1.2.4",
         "chalk": "^3.0.0",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
+        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
+        "semver": "^6.3.0",
         "shell-quote": "1.6.1"
       },
       "dependencies": {
@@ -29761,6 +33786,12 @@
           "requires": {
             "is-wsl": "^1.1.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "peer": true
         },
         "shell-quote": {
           "version": "1.6.1",
@@ -29798,9 +33829,9 @@
       "peer": true
     },
     "@react-native/polyfills": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-1.0.0.tgz",
-      "integrity": "sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
+      "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
       "peer": true
     },
     "@restart/context": {
@@ -29871,9 +33902,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+          "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
           "peer": true
         }
       }
@@ -31039,9 +35070,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "amazon-cognito-identity-js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.1.0.tgz",
-      "integrity": "sha512-zGJo9jpTBHaTrir9nBWxMnteR+uPMSq3SO9AT0EOAO/e1CyJ27sawe0Pd3218HPzsooOMZt0iYaWkpVrsQ3nSQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.0.tgz",
+      "integrity": "sha512-7nRkGb9Cinf1rD5t34B0NDWXO7lmyapXzLmSXq4IBOdiBMrmxToEHcRwfwT2jJfBWzzZiOS0gvQhKI32A+rmvg==",
       "requires": {
         "buffer": "4.9.2",
         "crypto-js": "^4.1.1",
@@ -31157,9 +35188,9 @@
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -31359,6 +35390,23 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
+    "ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "peer": true
+        }
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -31417,22 +35465,23 @@
       }
     },
     "aws-amplify": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.2.9.tgz",
-      "integrity": "sha512-kMbXfgmcTjN3KLsMYAGBe7iy8Ih1/3Den5ZPEvEg7YTlkgtQ7YguyltdekE/yHV5JCCKTB8G1D2wmsvfHkid5w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.1.tgz",
+      "integrity": "sha512-dvBVTDbpMfS91E0b9qxltIALTCP3b2pQpTyVQxUa9tuevEsi4YFL7EDcvQF4ScJkNwnuoTKVJsNCjrq8SJCJMg==",
       "requires": {
-        "@aws-amplify/analytics": "5.0.15",
-        "@aws-amplify/api": "4.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/datastore": "3.4.3",
-        "@aws-amplify/interactions": "4.0.15",
-        "@aws-amplify/predictions": "4.0.15",
-        "@aws-amplify/pubsub": "4.1.7",
-        "@aws-amplify/storage": "4.3.10",
+        "@aws-amplify/analytics": "5.0.19",
+        "@aws-amplify/api": "4.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/datastore": "3.4.7",
+        "@aws-amplify/geo": "1.1.1",
+        "@aws-amplify/interactions": "4.0.19",
+        "@aws-amplify/predictions": "4.0.19",
+        "@aws-amplify/pubsub": "4.1.11",
+        "@aws-amplify/storage": "4.4.2",
         "@aws-amplify/ui": "2.0.3",
-        "@aws-amplify/xr": "3.0.15"
+        "@aws-amplify/xr": "3.0.19"
       }
     },
     "axe-core": {
@@ -31452,6 +35501,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+    },
+    "babel-core": {
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "peer": true,
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -31985,9 +36041,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "version": "1.6.49",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
+      "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
       "peer": true
     },
     "big.js": {
@@ -32400,6 +36456,23 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
       "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
     },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        }
+      }
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -32593,9 +36666,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "peer": true
     },
     "cliui": {
@@ -32785,6 +36858,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "peer": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -33837,11 +37916,18 @@
       }
     },
     "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "^2.2.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        }
       }
     },
     "domutils": {
@@ -35083,11 +39169,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-xml-parser": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.20.0.tgz",
-      "integrity": "sha512-cMQwDJYVDjMPU56DviszewgMKuNzuf4NQSBuDf9RgZ6FKm5QEMxW05Za8lvnuL6moxoeZVUWBlL733WmovvV6g==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.20.3.tgz",
+      "integrity": "sha512-FfHJ/QCpo4K2gquBX7dIAcmShSBG4dMtYJ3ghSiR4w7YqlUujuamrM57C+mKLNWS3mvZzmm2B2Qx8Q6Gfw+lDQ==",
       "requires": {
-        "strnum": "^1.0.3"
+        "strnum": "^1.0.4"
       }
     },
     "fastq": {
@@ -35310,6 +39396,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg=="
+    },
+    "flow-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
+      "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
+      "peer": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -35851,9 +39943,9 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "hermes-engine": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.8.1.tgz",
-      "integrity": "sha512-as9Iccj/qrqqtDmfYUHbOIjt5xsQbUB6pjNIW3i1+RVr+pCAdz5S8/Jry778mz3rJWplYzHWdR1u1xQSYfBRYw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.9.0.tgz",
+      "integrity": "sha512-r7U+Y4P2Qg/igFVZN+DpT7JFfXUn1MM4dFne8aW+cCrF6RRymof+VqrUHs1kl07j8h8V2CNesU19RKgWbr3qPw==",
       "peer": true
     },
     "hermes-parser": {
@@ -35994,31 +40086,39 @@
       }
     },
     "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
       },
       "dependencies": {
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
           }
         }
       }
@@ -37889,9 +41989,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+          "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
           "peer": true
         },
         "@hapi/topo": {
@@ -37929,6 +42029,144 @@
       "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-250230.2.1.tgz",
       "integrity": "sha512-KmxeBlRjwoqCnBBKGsihFtvsBHyUFlBxJPK4FzeYcIuBfdjv6jFys44JITAgSTbQD+vIdwMEfyZklsuQX0yI1Q==",
       "peer": true
+    },
+    "jscodeshift": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.11.0.tgz",
+      "integrity": "sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==",
+      "peer": true,
+      "requires": {
+        "@babel/core": "^7.1.6",
+        "@babel/parser": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.1.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/preset-flow": "^7.0.0",
+        "@babel/preset-typescript": "^7.1.0",
+        "@babel/register": "^7.0.0",
+        "babel-core": "^7.0.0-bridge.0",
+        "colors": "^1.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^3.1.10",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.20.3",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^2.3.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "peer": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "peer": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "peer": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "peer": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "peer": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "peer": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "peer": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "peer": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "peer": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
     },
     "jsdom": {
       "version": "16.6.0",
@@ -38455,6 +42693,11 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -38629,6 +42872,24 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "peer": true
+        },
+        "temp": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+          "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+          "peer": true,
+          "requires": {
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+              "peer": true
+            }
+          }
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -39404,6 +43665,15 @@
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==",
       "peer": true
+    },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "peer": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -41626,6 +45896,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -41910,9 +46185,9 @@
       }
     },
     "react-devtools-core": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.18.0.tgz",
-      "integrity": "sha512-Kg/LhDkdt9J0ned1D1RfeuSdX4cKW83/valJLYswGdsYc0g2msmD0kfYozsaRacjDoZwcKlxGOES1wrkET5O6Q==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.19.1.tgz",
+      "integrity": "sha512-2wJiGffPWK0KggBjVwnTaAk+Z3MSxKInHmdzPTrBh1mAarexsa93Kw+WMX88+XjN+TtYgAiLe9xeTqcO5FfJTw==",
       "peer": true,
       "requires": {
         "shell-quote": "^1.6.1",
@@ -41955,6 +46230,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-native-codegen": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.0.7.tgz",
+      "integrity": "sha512-dwNgR8zJ3ALr480QnAmpTiqvFo+rDtq6V5oCggKhYFlRjzOmVSFn3YD41u8ltvKS5G2nQ8gCs2vReFFnRGLYng==",
+      "peer": true,
+      "requires": {
+        "flow-parser": "^0.121.0",
+        "jscodeshift": "^0.11.0",
+        "nullthrows": "^1.1.1"
+      }
     },
     "react-overlays": {
       "version": "5.0.1",
@@ -42207,6 +46493,32 @@
         "picomatch": "^2.2.1"
       }
     },
+    "readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=",
+      "peer": true
+    },
+    "recast": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "peer": true,
+      "requires": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "peer": true
+        }
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -42322,21 +46634,71 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "renderkid": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.5.tgz",
-      "integrity": "sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
       "requires": {
-        "css-select": "^2.0.2",
-        "dom-converter": "^0.2",
-        "htmlparser2": "^3.10.1",
-        "lodash": "^4.17.20",
-        "strip-ansi": "^3.0.0"
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "css-select": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+          "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^5.0.0",
+            "domhandler": "^4.2.0",
+            "domutils": "^2.6.0",
+            "nth-check": "^2.0.0"
+          }
+        },
+        "css-what": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
+        },
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "nth-check": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+          "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+          "requires": {
+            "boolbase": "^1.0.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -43815,9 +48177,9 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "strnum": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.3.tgz",
-      "integrity": "sha512-GVoRjsqAYZkAH16GDzfTuafuwKxzKdaaCQyLaWf37gOP1e2PPbAKWoME1OmO+c4RCKMfNrrPRDLFCNBFU45N/A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.4.tgz",
+      "integrity": "sha512-lMzNMfDpaQOLt4B2mEbfzYS0+T7dvCXeojnlGf6f1AygvWDMcWyXYaLbyICfjVu29sErR8fnRagQfBW/N/hGgw=="
     },
     "style-loader": {
       "version": "1.3.0",
@@ -44006,20 +48368,22 @@
       }
     },
     "temp": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
       "peer": true,
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "rimraf": "~2.6.2"
       },
       "dependencies": {
         "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "peer": true
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "peer": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -44208,9 +48572,9 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -46089,6 +50453,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "peer": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
     },
     "ws": {
       "version": "7.4.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/awslabs/amazon-s3-find-and-forget"
   },
   "dependencies": {
-    "@aws-amplify/ui-components": "^1.7.8",
-    "@aws-amplify/ui-react": "^1.2.15",
+    "@aws-amplify/ui-components": "^1.8.2",
+    "@aws-amplify/ui-react": "^1.2.19",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "aws-amplify": "^4.2.9",
+    "aws-amplify": "^4.3.1",
     "bootstrap": "^4.4.1",
     "react": "^16.14.0",
     "react-bootstrap": "^1.0.0",

--- a/frontend/src/utils/request.js
+++ b/frontend/src/utils/request.js
@@ -1,5 +1,6 @@
 import Amplify, { API, Auth } from "aws-amplify";
 import { retryWrapper } from "./retryWrapper";
+import { isUndefined } from "./";
 
 const settings = window.s3f2Settings || {};
 const region = settings.region || "eu-west-1";
@@ -43,7 +44,7 @@ const apiWrapper = (api, endpoint, options) => {
     headers: headers || { "Content-Type": "application/json" },
     response: response || false
   };
-  if (data) reqOptions.body = data;
+  if (!isUndefined(data)) reqOptions.body = data;
   return retryWrapper(() => API[method || "get"](api, endpoint, reqOptions));
 };
 
@@ -61,4 +62,4 @@ export const glueGateway = (endpointName, data) =>
   });
 
 export const stsGateway = endpoint =>
-  apiWrapper("sts", endpoint, { method: "post" });
+  apiWrapper("sts", endpoint, { method: "post", data: {} });


### PR DESCRIPTION
*Issue #, if available:*
Closes #269 

*Description of changes:*

While updating Amplify in a couple of iterations ago, we introduced this bug. I noticed that compared to previous versions, the  body from the request script was being sent as `null` (stringified) while before it was sent empty. That caused a sigv4 mismatch causing 403. Perhaps a (un?)wanted breaking change on the Amplify library side.

By setting up an explicit empty body `{}` I noticed that the request succeeded.

*PR Checklist:*

- [ ] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
