### PR TITLE
Fix parquet multiple column identifier bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.37 (unreleased)
+
+- [#274](https://github.com/awslabs/amazon-s3-find-and-forget/pull/274):
+  Fix for a bug that causes deletion to fail in parquet files when a data
+  mapper has multiple column identifiers.
+
 ## v0.36
 
 - [#272](https://github.com/awslabs/amazon-s3-find-and-forget/pull/272):

--- a/backend/ecs_tasks/delete_files/parquet_handler.py
+++ b/backend/ecs_tasks/delete_files/parquet_handler.py
@@ -129,6 +129,8 @@ def delete_from_table(table, to_delete):
             )
         )
         table = table.filter(~indexes)
+        if not table.num_rows:
+            break
     deleted_rows = initial_rows - table.num_rows
     return table, deleted_rows
 

--- a/tests/unit/ecs_tasks/test_parquet.py
+++ b/tests/unit/ecs_tasks/test_parquet.py
@@ -92,6 +92,22 @@ def test_delete_correct_rows_from_table():
     assert table.to_pydict() == {"customer_id": ["34567"]}
 
 
+def test_delete_handles_multiple_columns_with_no_rows_left():
+    data = [
+        {"customer_id": "12345", "other_customer_id": "23456"},
+    ]
+    columns = [
+        {"Column": "customer_id", "MatchIds": ["12345"], "Type": "Simple"},
+        {"Column": "other_customer_id", "MatchIds": ["23456"], "Type": "Simple"},
+    ]
+    df = pd.DataFrame(data)
+    table = pa.Table.from_pandas(df)
+    table, deleted_rows = delete_from_table(table, columns)
+    res = table.to_pandas()
+    assert len(res) == 0
+    assert deleted_rows == 1
+
+
 def test_handles_lower_cased_column_names():
     data = [
         {"userData": {"customerId": "12345"}},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Deletion from some parquet files fails on [this line](https://github.com/awslabs/amazon-s3-find-and-forget/blob/master/backend/ecs_tasks/delete_files/parquet_handler.py#L131) with the following error:

> TypeError: ufunc 'invert' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''

The issue appears to be that `table` gets emptied out on the first iteration, so on the second iteration `indexes` is empty.

Verified that this PR fixes the issue.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
