### PR TITLE
Auto-refresh access tokens used by containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v0.37 (unreleased)
 
-- [#274](https://github.com/awslabs/amazon-s3-find-and-forget/pull/274):
-  Fix for a bug that causes deletion to fail in parquet files when a data
-  mapper has multiple column identifiers.
+- [#274](https://github.com/awslabs/amazon-s3-find-and-forget/pull/274): Fix for
+  a bug that causes deletion to fail in parquet files when a data mapper has
+  multiple column identifiers.
 
 ## v0.36
 

--- a/backend/ecs_tasks/delete_files/requirements.in
+++ b/backend/ecs_tasks/delete_files/requirements.in
@@ -6,3 +6,4 @@ boto3==1.17.85
 numpy==1.19.1
 cryptography==3.4.7
 urllib3>=1.26.5
+aws-assume-role-lib>=2.9.0

--- a/backend/ecs_tasks/delete_files/requirements.txt
+++ b/backend/ecs_tasks/delete_files/requirements.txt
@@ -4,9 +4,12 @@
 #
 #    pip-compile --output-file=backend/ecs_tasks/delete_files/requirements.txt backend/ecs_tasks/delete_files/requirements.in
 #
+aws-assume-role-lib==2.9.0
+    # via -r backend/ecs_tasks/delete_files/requirements.in
 boto3==1.17.85
     # via
     #   -r backend/ecs_tasks/delete_files/requirements.in
+    #   aws-assume-role-lib
     #   s3fs
 botocore==1.20.85
     # via

--- a/backend/lambda_layers/aws_sdk/requirements.in
+++ b/backend/lambda_layers/aws_sdk/requirements.in
@@ -1,2 +1,3 @@
 boto3==1.17.85
 urllib3>=1.26.5
+aws-assume-role-lib>=2.9.0

--- a/backend/lambda_layers/aws_sdk/requirements.txt
+++ b/backend/lambda_layers/aws_sdk/requirements.txt
@@ -4,8 +4,12 @@
 #
 #    pip-compile --output-file=backend/lambda_layers/aws_sdk/requirements.txt backend/lambda_layers/aws_sdk/requirements.in
 #
-boto3==1.17.85
+aws-assume-role-lib==2.9.0
     # via -r backend/lambda_layers/aws_sdk/requirements.in
+boto3==1.17.85
+    # via
+    #   -r backend/lambda_layers/aws_sdk/requirements.in
+    #   aws-assume-role-lib
 botocore==1.20.85
     # via
     #   boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,10 @@ attrs==20.1.0
     #   black
     #   jsonschema
     #   pytest
+aws-assume-role-lib==2.9.0
+    # via
+    #   -r ./backend/ecs_tasks/delete_files/requirements.txt
+    #   -r ./backend/lambda_layers/aws_sdk/requirements.txt
 aws-sam-translator==1.35.0
     # via cfn-lint
 black==19.10b0
@@ -22,6 +26,7 @@ boto3==1.17.85
     # via
     #   -r ./backend/ecs_tasks/delete_files/requirements.txt
     #   -r ./backend/lambda_layers/aws_sdk/requirements.txt
+    #   aws-assume-role-lib
     #   aws-sam-translator
     #   s3fs
 botocore==1.20.85

--- a/templates/deletion_flow.yaml
+++ b/templates/deletion_flow.yaml
@@ -136,6 +136,8 @@ Resources:
               awslogs-region: !Ref 'AWS::Region'
               awslogs-stream-prefix: !Ref 'AWS::StackName'
           Environment:
+            - Name: AWS_STS_REGIONAL_ENDPOINTS
+              Value: regional
             - Name: DELETE_OBJECTS_QUEUE
               Value: !Ref DelObjQ
             - Name: ECS_ENABLE_CONTAINER_METADATA

--- a/tests/unit/lambda_layers/test_boto_utils.py
+++ b/tests/unit/lambda_layers/test_boto_utils.py
@@ -393,29 +393,19 @@ def test_it_fetches_userinfo_from_lambda_event_with_failover_in_place():
     assert result == {"Username": "N/A", "Sub": "N/A"}
 
 
-@patch("boto_utils.sts")
-def test_it_returns_default_session(mock_sts):
+@patch("boto_utils.assume_role")
+def test_it_returns_default_session(mock_assume_role):
     resp = get_session()
-    mock_sts.assume_role.assert_not_called()
+    mock_assume_role.assert_not_called()
     assert isinstance(resp, Session)
 
 
 @patch("boto_utils.boto3")
-@patch("boto_utils.sts")
-def test_it_assumes_role_for_session_where_given(mock_sts, mock_boto):
-    mock_sts.assume_role.return_value = {
-        "Credentials": {
-            "AccessKeyId": "a",
-            "SecretAccessKey": "b",
-            "SessionToken": "c",
-        }
-    }
+@patch("boto_utils.assume_role")
+def test_it_assumes_role_for_session_where_given(mock_assume_role, mock_boto):
     get_session(assume_role_arn="arn:aws:iam:accountid::role/rolename")
-    mock_sts.assume_role.assert_called_with(
-        RoleArn="arn:aws:iam:accountid::role/rolename", RoleSessionName=ANY
-    )
-    mock_boto.session.Session.assert_called_with(
-        aws_access_key_id="a", aws_secret_access_key="b", aws_session_token="c",
+    mock_assume_role.assert_called_with(
+        ANY, "arn:aws:iam:accountid::role/rolename", RoleSessionName=ANY
     )
 
 


### PR DESCRIPTION
*Description of changes:*

This is a PR to fix a bug observed when processing takes more than an hour, causing the expiration of an access token. This is an example of a exception:

```
2021-11-02T07:17:27.424-07:00	[INFO] Generating new file without matches
2021-11-02T08:18:06.356-07:00	[ERROR] ClientError: An error occurred (ExpiredToken) when calling the GetBucketRequestPayment operation: The provided token has expired.
```

I investigated increasing the token validity to 12 hours, but unfortunately the maximum duration for temporary credentials is 1 hour. I decided to setup a mechanism to auto-refresh tokens but then I bumped into this [blogpost](https://ben11kehoe.medium.com/boto3-sessions-and-why-you-should-use-them-9b094eb5ca8e), which also came with a handy python library that I manually tested and worked perfectly (I manually created a 15m sleep with a token validity of 15m and it correctly performed the refresh and succeeded).

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
