### PR TITLE
Make sure s3fs uses the session rather than stale token after expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v0.38
 
 - [#278](https://github.com/awslabs/amazon-s3-find-and-forget/pull/278): Fix for
-  a bug that causes the access token to expire and cause a Job to fail if
-  processing of an object takes more than an hour
+  a bug that caused a job to fail if the processing of an object took longer
+  than the lifetime of its IAM temporary access credentials.
 
 ## v0.37
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Change Log
 
-## v0.37
+## v0.38
 
-- [#276](https://github.com/awslabs/amazon-s3-find-and-forget/pull/276): Fix for
+- [#278](https://github.com/awslabs/amazon-s3-find-and-forget/pull/278): Fix for
   a bug that causes the access token to expire and cause a Job to fail if
   processing of an object takes more than an hour
+
+## v0.37
+
+- [#276](https://github.com/awslabs/amazon-s3-find-and-forget/pull/276): First
+  attempt for fixing a bug that causes the access token to expire and cause a
+  Job to fail if processing of an object takes more than an hour
 
 - [#275](https://github.com/awslabs/amazon-s3-find-and-forget/pull/275): Upgrade
   JavaScript dependencies

--- a/backend/ecs_tasks/delete_files/main.py
+++ b/backend/ecs_tasks/delete_files/main.py
@@ -130,11 +130,8 @@ def execute(queue_url, message_body, receipt_handle):
         input_bucket, input_key = parse_s3_url(object_path)
         validate_bucket_versioning(client, input_bucket)
         match_ids = build_matches(cols, manifest_object)
-        creds = session.get_credentials().get_frozen_credentials()
         s3 = s3fs.S3FileSystem(
-            key=creds.access_key,
-            secret=creds.secret_key,
-            token=creds.token,
+            session=session,
             default_cache_type="none",
             requester_pays=True,
             default_fill_cache=False,

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.37)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.38)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -144,7 +144,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.37'
+      Version: 'v0.38'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Issue #, if available:*
In #276 I managed to solve the expiration token issue happening when using the s3 boto client by using the library that wraps the session handling. Unfortunately, when doing more testing, I bumped into a new bug: `ObjectUpdateFailed` with `"Unable to retrieve object: Write failed: TypeError(\"'NoneType' object is not subscriptable\")"`.

After doing some digging, I found that while the previous PR solved the issue by refreshing the token from the client (https://github.com/awslabs/amazon-s3-find-and-forget/blob/master/backend/ecs_tasks/delete_files/s3.py#L18-L21), the S3fs client was still using stale credentials. By passing in the session to the s3fs factory, I verified the issue is fixed by artificially creating a 1h sleep and waiting for it to be reproduced and then fixed.
Sorry for not catching this earlier. In my previous test I only tested for 15m expiration, which didn't catch this scenario.

*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
