### PR TITLE
Improve performance for large queues of simple matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Change Log
 
+## v0.39
+
+- [#279](https://github.com/awslabs/amazon-s3-find-and-forget/pull/279): Improve
+  performance for large queues of simple matches
+
 ## v0.38
 
 - [#278](https://github.com/awslabs/amazon-s3-find-and-forget/pull/278): Fix for
   a bug that caused a job to fail if the processing of an object took longer
-  than the lifetime of its IAM temporary access credentials.
+  than the lifetime of its IAM temporary access credentials
 
 ## v0.37
 
@@ -17,7 +22,7 @@
 
 - [#274](https://github.com/awslabs/amazon-s3-find-and-forget/pull/274): Fix for
   a bug that causes deletion to fail in parquet files when a data mapper has
-  multiple column identifiers.
+  multiple column identifiers
 
 ## v0.36
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.39
 
 - [#279](https://github.com/awslabs/amazon-s3-find-and-forget/pull/279): Improve
-  performance for large queues of simple matches
+  performance for large queues of simple matches and logging additions
 
 ## v0.38
 

--- a/backend/ecs_tasks/delete_files/main.py
+++ b/backend/ecs_tasks/delete_files/main.py
@@ -159,6 +159,7 @@ def execute(queue_url, message_body, receipt_handle):
         with pa.BufferReader(out_sink.getvalue()) as output_buf:
             if is_encrypted:
                 output_buf, metadata = encrypt(output_buf, metadata, kms_client)
+            logger.info("Uploading new object version to S3")
             new_version = save(
                 s3,
                 client,

--- a/backend/ecs_tasks/delete_files/parquet_handler.py
+++ b/backend/ecs_tasks/delete_files/parquet_handler.py
@@ -69,6 +69,7 @@ def get_row_indexes_to_delete(table, identifier, to_delete):
     can be simple like "customer_id" or complex like "user.info.id"
     """
     indexes = []
+    to_delete_set = set(to_delete)
     segments = identifier.split(".")
     column_identifier = case_insensitive_getter(table.column_names, segments[0])
     for obj in table.column(column_identifier).to_pylist():
@@ -76,7 +77,7 @@ def get_row_indexes_to_delete(table, identifier, to_delete):
         for i in range(1, len(segments)):
             next_segment = case_insensitive_getter(list(current.keys()), segments[i])
             current = current[next_segment]
-        indexes.append(current in to_delete)
+        indexes.append(current in to_delete_set)
     return np.array(indexes)
 
 
@@ -129,7 +130,7 @@ def delete_from_table(table, to_delete):
     for column in to_delete:
         column = cast_column_values(column, table.schema)
         indexes = (
-            get_row_indexes_to_delete(table, column["Column"], set(column["MatchIds"]))
+            get_row_indexes_to_delete(table, column["Column"], column["MatchIds"])
             if column["Type"] == "Simple"
             else get_row_indexes_to_delete_for_composite(
                 table, column["Columns"], column["MatchIds"]

--- a/backend/ecs_tasks/delete_files/parquet_handler.py
+++ b/backend/ecs_tasks/delete_files/parquet_handler.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 import logging
+import os
+import sys
 from collections import Counter
 
 import numpy as np
@@ -7,6 +9,11 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("LOG_LEVEL", logging.INFO))
+formatter = logging.Formatter("[%(levelname)s] %(message)s")
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 
 def load_parquet(f):
@@ -122,7 +129,7 @@ def delete_from_table(table, to_delete):
     for column in to_delete:
         column = cast_column_values(column, table.schema)
         indexes = (
-            get_row_indexes_to_delete(table, column["Column"], column["MatchIds"])
+            get_row_indexes_to_delete(table, column["Column"], set(column["MatchIds"]))
             if column["Type"] == "Simple"
             else get_row_indexes_to_delete_for_composite(
                 table, column["Columns"], column["MatchIds"]

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.38)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.39)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -144,7 +144,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.38'
+      Version: 'v0.39'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*

When processing a job with a large queue, there may be some performance issues in the Forget phase. In particular, with a queue of 10K matches in a dataset of 2 objects of 300MB each, I was able to complete the job only after 50m, as opposite of a couple of minutes when the same dataset had 1 match in the queue (of which the actual compute was a bunch of seconds).

After this improvement, I was able to obtain the same result for the large queue. Note that this helps only with simple matches, as composite still iterate over lists. I plan to address that in a separate PR as I think that is a bit more complex and I need more time to think about it.

*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
