### PR TITLE
Improve performance for large queues of composite matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.40
+
+- [#280](https://github.com/awslabs/amazon-s3-find-and-forget/pull/280): Improve
+  performance for large queues of composite matches
+
 ## v0.39
 
 - [#279](https://github.com/awslabs/amazon-s3-find-and-forget/pull/279): Improve

--- a/backend/ecs_tasks/delete_files/parquet_handler.py
+++ b/backend/ecs_tasks/delete_files/parquet_handler.py
@@ -40,6 +40,9 @@ def get_row_indexes_to_delete_for_composite(table, identifiers, to_delete):
     """
     indexes = []
     data = {}
+    to_delete_set = set()
+    for composite_match in to_delete:
+        to_delete_set.add(tuple(composite_match))
     for identifier in identifiers:
         column_first_level = identifier.split(".")[0].lower()
         if not column_first_level in data:
@@ -58,7 +61,7 @@ def get_row_indexes_to_delete_for_composite(table, identifiers, to_delete):
                 )
                 current = current[next_segment]
             values_array.append(current)
-        indexes.append(values_array in to_delete)
+        indexes.append(tuple(values_array) in to_delete_set)
     return np.array(indexes)
 
 

--- a/backend/ecs_tasks/delete_files/parquet_handler.py
+++ b/backend/ecs_tasks/delete_files/parquet_handler.py
@@ -40,9 +40,7 @@ def get_row_indexes_to_delete_for_composite(table, identifiers, to_delete):
     """
     indexes = []
     data = {}
-    to_delete_set = set()
-    for composite_match in to_delete:
-        to_delete_set.add(tuple(composite_match))
+    to_delete_set = {tuple(composite_match) for composite_match in to_delete}
     for identifier in identifiers:
         column_first_level = identifier.split(".")[0].lower()
         if not column_first_level in data:

--- a/backend/ecs_tasks/delete_files/parquet_handler.py
+++ b/backend/ecs_tasks/delete_files/parquet_handler.py
@@ -40,7 +40,7 @@ def get_row_indexes_to_delete_for_composite(table, identifiers, to_delete):
     """
     indexes = []
     data = {}
-    to_delete_set = {tuple(composite_match) for composite_match in to_delete}
+    to_delete_set = set(map(tuple, to_delete))
     for identifier in identifiers:
         column_first_level = identifier.split(".")[0].lower()
         if not column_first_level in data:

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.39)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.40)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -144,7 +144,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.39'
+      Version: 'v0.40'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*

Following #279 this is an equivalent improvement for composite matches. I tested again manually a 10K size queue with and without the change in order to prove that the job completed after a couple of seconds with the change, as opposite of being stuck for an hour.

*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
