### PR TITLE
Improve performance of query generation step (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.41 (unreleased)
+
+- [#281](https://github.com/awslabs/amazon-s3-find-and-forget/pull/281): Improve
+  performance of query generation step for tables with many partitions
+
 ## v0.40
 
 - [#280](https://github.com/awslabs/amazon-s3-find-and-forget/pull/280): Improve

--- a/tests/unit/tasks/test_generate_queries.py
+++ b/tests/unit/tasks/test_generate_queries.py
@@ -23,6 +23,16 @@ with patch.dict(os.environ, {"QueryQueue": "test"}):
 pytestmark = [pytest.mark.unit, pytest.mark.task]
 
 
+def lists_equal_ignoring_order(a, b):
+    a = a.copy()
+    try:
+        for item in b:
+            a.remove(item)
+    except ValueError:
+        return False
+    return not a
+
+
 @patch("backend.lambdas.tasks.generate_queries.write_partitions")
 @patch("backend.lambdas.tasks.generate_queries.batch_sqs_msgs")
 @patch("backend.lambdas.tasks.generate_queries.get_deletion_queue")
@@ -972,50 +982,53 @@ class TestAthenaQueries:
             "job_1234567890",
         )
 
-        assert resp == [
-            {
-                "DataMapperId": "a",
-                "Database": "test_db",
-                "Table": "test_table",
-                "QueryExecutor": "athena",
-                "Format": "parquet",
-                "Columns": [{"Column": "customer_id", "Type": "Simple"}],
-                "PartitionKeys": [
-                    {"Key": "year", "Value": "2018"},
-                    {"Key": "month", "Value": "12"},
-                ],
-                "DeleteOldVersions": True,
-                "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
-            },
-            {
-                "DataMapperId": "a",
-                "Database": "test_db",
-                "Table": "test_table",
-                "QueryExecutor": "athena",
-                "Format": "parquet",
-                "Columns": [{"Column": "customer_id", "Type": "Simple"}],
-                "PartitionKeys": [
-                    {"Key": "year", "Value": "2019"},
-                    {"Key": "month", "Value": "01"},
-                ],
-                "DeleteOldVersions": True,
-                "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
-            },
-            {
-                "DataMapperId": "a",
-                "Database": "test_db",
-                "Table": "test_table",
-                "QueryExecutor": "athena",
-                "Format": "parquet",
-                "Columns": [{"Column": "customer_id", "Type": "Simple"}],
-                "PartitionKeys": [
-                    {"Key": "year", "Value": "2019"},
-                    {"Key": "month", "Value": "02"},
-                ],
-                "DeleteOldVersions": True,
-                "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
-            },
-        ]
+        assert lists_equal_ignoring_order(
+            resp,
+            [
+                {
+                    "DataMapperId": "a",
+                    "Database": "test_db",
+                    "Table": "test_table",
+                    "QueryExecutor": "athena",
+                    "Format": "parquet",
+                    "Columns": [{"Column": "customer_id", "Type": "Simple"}],
+                    "PartitionKeys": [
+                        {"Key": "year", "Value": "2018"},
+                        {"Key": "month", "Value": "12"},
+                    ],
+                    "DeleteOldVersions": True,
+                    "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
+                },
+                {
+                    "DataMapperId": "a",
+                    "Database": "test_db",
+                    "Table": "test_table",
+                    "QueryExecutor": "athena",
+                    "Format": "parquet",
+                    "Columns": [{"Column": "customer_id", "Type": "Simple"}],
+                    "PartitionKeys": [
+                        {"Key": "year", "Value": "2019"},
+                        {"Key": "month", "Value": "01"},
+                    ],
+                    "DeleteOldVersions": True,
+                    "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
+                },
+                {
+                    "DataMapperId": "a",
+                    "Database": "test_db",
+                    "Table": "test_table",
+                    "QueryExecutor": "athena",
+                    "Format": "parquet",
+                    "Columns": [{"Column": "customer_id", "Type": "Simple"}],
+                    "PartitionKeys": [
+                        {"Key": "year", "Value": "2019"},
+                        {"Key": "month", "Value": "02"},
+                    ],
+                    "DeleteOldVersions": True,
+                    "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
+                },
+            ],
+        )
         put_object_mock.put_object.assert_called_with(
             Key="manifests/job_1234567890/a/manifest.json",
             Body=(
@@ -1073,38 +1086,41 @@ class TestAthenaQueries:
             "job_1234567890",
         )
 
-        assert resp == [
-            {
-                "DataMapperId": "a",
-                "Database": "test_db",
-                "Table": "test_table",
-                "QueryExecutor": "athena",
-                "Format": "parquet",
-                "Columns": [{"Column": "customer_id", "Type": "Simple"}],
-                "PartitionKeys": [
-                    {"Key": "year", "Value": "2018"},
-                    {"Key": "month", "Value": "12"},
-                ],
-                "RoleArn": "arn:aws:iam::accountid:role/rolename",
-                "DeleteOldVersions": True,
-                "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
-            },
-            {
-                "DataMapperId": "a",
-                "Database": "test_db",
-                "Table": "test_table",
-                "QueryExecutor": "athena",
-                "Format": "parquet",
-                "Columns": [{"Column": "customer_id", "Type": "Simple"}],
-                "PartitionKeys": [
-                    {"Key": "year", "Value": "2019"},
-                    {"Key": "month", "Value": "01"},
-                ],
-                "RoleArn": "arn:aws:iam::accountid:role/rolename",
-                "DeleteOldVersions": True,
-                "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
-            },
-        ]
+        assert lists_equal_ignoring_order(
+            resp,
+            [
+                {
+                    "DataMapperId": "a",
+                    "Database": "test_db",
+                    "Table": "test_table",
+                    "QueryExecutor": "athena",
+                    "Format": "parquet",
+                    "Columns": [{"Column": "customer_id", "Type": "Simple"}],
+                    "PartitionKeys": [
+                        {"Key": "year", "Value": "2018"},
+                        {"Key": "month", "Value": "12"},
+                    ],
+                    "RoleArn": "arn:aws:iam::accountid:role/rolename",
+                    "DeleteOldVersions": True,
+                    "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
+                },
+                {
+                    "DataMapperId": "a",
+                    "Database": "test_db",
+                    "Table": "test_table",
+                    "QueryExecutor": "athena",
+                    "Format": "parquet",
+                    "Columns": [{"Column": "customer_id", "Type": "Simple"}],
+                    "PartitionKeys": [
+                        {"Key": "year", "Value": "2019"},
+                        {"Key": "month", "Value": "01"},
+                    ],
+                    "RoleArn": "arn:aws:iam::accountid:role/rolename",
+                    "DeleteOldVersions": True,
+                    "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
+                },
+            ],
+        )
         put_object_mock.put_object.assert_called_with(
             Key="manifests/job_1234567890/a/manifest.json",
             Body=(
@@ -1551,30 +1567,33 @@ class TestAthenaQueries:
             "job_1234567890",
         )
 
-        assert resp == [
-            {
-                "DataMapperId": "a",
-                "QueryExecutor": "athena",
-                "Format": "parquet",
-                "Database": "test_db",
-                "Table": "test_table",
-                "Columns": [{"Column": "customer_id", "Type": "Simple"}],
-                "PartitionKeys": [{"Key": "year", "Value": "2018"}],
-                "DeleteOldVersions": True,
-                "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
-            },
-            {
-                "DataMapperId": "a",
-                "QueryExecutor": "athena",
-                "Format": "parquet",
-                "Database": "test_db",
-                "Table": "test_table",
-                "Columns": [{"Column": "customer_id", "Type": "Simple"}],
-                "PartitionKeys": [{"Key": "year", "Value": "2019"}],
-                "DeleteOldVersions": True,
-                "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
-            },
-        ]
+        assert lists_equal_ignoring_order(
+            resp,
+            [
+                {
+                    "DataMapperId": "a",
+                    "QueryExecutor": "athena",
+                    "Format": "parquet",
+                    "Database": "test_db",
+                    "Table": "test_table",
+                    "Columns": [{"Column": "customer_id", "Type": "Simple"}],
+                    "PartitionKeys": [{"Key": "year", "Value": "2018"}],
+                    "DeleteOldVersions": True,
+                    "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
+                },
+                {
+                    "DataMapperId": "a",
+                    "QueryExecutor": "athena",
+                    "Format": "parquet",
+                    "Database": "test_db",
+                    "Table": "test_table",
+                    "Columns": [{"Column": "customer_id", "Type": "Simple"}],
+                    "PartitionKeys": [{"Key": "year", "Value": "2019"}],
+                    "DeleteOldVersions": True,
+                    "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
+                },
+            ],
+        )
         put_object_mock.put_object.assert_called_with(
             Key="manifests/job_1234567890/a/manifest.json",
             Body=(


### PR DESCRIPTION
*Description of changes:*
Query generation step times out (i.e. takes longer than 15 minutes) when a table has many partitions. I was able to reproduce the issue in a test environment with a table containing 70000 partitions.

After this change, query generation for the same table completes in about 6 minutes.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
