### PR TITLE
Improve performance of find query for data mappers with multiple column identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.42 (unreleased)
+
+- [#284](https://github.com/awslabs/amazon-s3-find-and-forget/pull/284): Improve
+  performance of find query for data mappers with multiple column identifiers
+
 ## v0.41
 
 - [#283](https://github.com/awslabs/amazon-s3-find-and-forget/pull/283): Fix for

--- a/tests/unit/tasks/test_execute_query.py
+++ b/tests/unit/tasks/test_execute_query.py
@@ -63,15 +63,16 @@ def test_it_generates_query_with_partition():
     )
     assert escape_resp(resp) == escape_resp(
         """
-            SELECT DISTINCT t."$path"
-            FROM "amazonreviews"."amazon_reviews_parquet" t,
-                "s3f2_manifests_database"."s3f2_manifests_table" m
-            WHERE m."jobid"='job_1234567890'
-            AND m."datamapperid"='dm_1234' AND
-
-            ((cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'))
-
-            AND "product_category" = 'Books'
+            SELECT DISTINCT "$path" FROM (
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'
+                    AND "product_category" = 'Books'
+            )
         """
     )
 
@@ -89,15 +90,16 @@ def test_it_generates_query_with_int_partition():
     )
     assert escape_resp(resp) == escape_resp(
         """
-            SELECT DISTINCT t."$path"
-            FROM "amazonreviews"."amazon_reviews_parquet" t,
-                "s3f2_manifests_database"."s3f2_manifests_table" m
-            WHERE m."jobid"='job_1234567890'
-            AND m."datamapperid"='dm_1234' AND
-
-            ((cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'))
-
-            AND "year" = 2010
+            SELECT DISTINCT "$path" FROM (
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'
+                    AND "year" = 2010
+            )
         """
     )
 
@@ -118,15 +120,16 @@ def test_it_generates_query_with_multiple_partitions():
     )
     assert escape_resp(resp) == escape_resp(
         """
-            SELECT DISTINCT t."$path"
-            FROM "amazonreviews"."amazon_reviews_parquet" t,
-                "s3f2_manifests_database"."s3f2_manifests_table" m
-            WHERE m."jobid"='job_1234567890'
-            AND m."datamapperid"='dm_1234' AND
-
-            ((cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'))
-
-            AND "product_category" = 'Books' AND "published" = '2019'
+            SELECT DISTINCT "$path" FROM (
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'
+                    AND "product_category" = 'Books'  AND "published" = '2019'
+            )
         """
     )
 
@@ -143,13 +146,15 @@ def test_it_generates_query_without_partition():
     )
     assert escape_resp(resp) == escape_resp(
         """
-            SELECT DISTINCT t."$path"
-            FROM "amazonreviews"."amazon_reviews_parquet" t,
-                "s3f2_manifests_database"."s3f2_manifests_table" m
-            WHERE m."jobid"='job_1234567890'
-            AND m."datamapperid"='dm_1234' AND
-
-            ((cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'))
+            SELECT DISTINCT "$path" FROM (
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'
+            )
         """
     )
 
@@ -169,14 +174,25 @@ def test_it_generates_query_with_multiple_columns():
     )
     assert escape_resp(resp) == escape_resp(
         """
-            SELECT DISTINCT t."$path"
-            FROM "amazonreviews"."amazon_reviews_parquet" t,
-                "s3f2_manifests_database"."s3f2_manifests_table" m
-            WHERE m."jobid"='job_1234567890'
-            AND m."datamapperid"='dm_1234' AND
+            SELECT DISTINCT "$path" FROM (
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."a" as varchar)=m."queryablematchid" AND m."queryablecolumns"='a'
 
-            ((cast(t."a" as varchar)=m."queryablematchid" AND m."queryablecolumns"='a') OR
-            (cast(t."b" as varchar)=m."queryablematchid" AND m."queryablecolumns"='b'))
+                UNION ALL
+
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."b" as varchar)=m."queryablematchid" AND m."queryablecolumns"='b'
+            )
         """
     )
 
@@ -193,13 +209,15 @@ def test_it_generates_query_with_columns_of_complex_type():
     )
     assert escape_resp(resp) == escape_resp(
         """
-            SELECT DISTINCT t."$path"
-            FROM "amazonreviews"."amazon_reviews_parquet" t,
-                "s3f2_manifests_database"."s3f2_manifests_table" m
-            WHERE m."jobid"='job_1234567890'
-            AND m."datamapperid"='dm_1234' AND
-
-            ((cast(t."a"."b"."c" as varchar)=m."queryablematchid" AND m."queryablecolumns"='a.b.c'))
+            SELECT DISTINCT "$path" FROM (
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."a"."b"."c" as varchar)=m."queryablematchid" AND m."queryablecolumns"='a.b.c'
+            )
         """
     )
 
@@ -223,19 +241,37 @@ def test_it_generates_query_with_composite_matches():
     )
     assert escape_resp(resp) == escape_resp(
         """
-            SELECT DISTINCT t."$path"
-            FROM "amazonreviews"."amazon_reviews_parquet" t,
-                "s3f2_manifests_database"."s3f2_manifests_table" m
-            WHERE m."jobid"='job_1234567890'
-            AND m."datamapperid"='dm_1234' AND
+            SELECT DISTINCT "$path" FROM (
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    concat(t."user"."first_name", '_S3F2COMP_', t."user"."last_name")=m."queryablematchid" AND
+                    m."queryablecolumns"='user.first_name_S3F2COMP_user.last_name'
 
-            ((concat(t."user"."first_name", '_S3F2COMP_', t."user"."last_name")=m."queryablematchid" AND
-            m."queryablecolumns"='user.first_name_S3F2COMP_user.last_name') OR
+                UNION ALL
 
-            (concat(t."user"."age", '_S3F2COMP_', t."user"."last_name")=m."queryablematchid" AND
-            m."queryablecolumns"='user.age_S3F2COMP_user.last_name') OR
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    concat(t."user"."age", '_S3F2COMP_', t."user"."last_name")=m."queryablematchid" AND
+                    m."queryablecolumns"='user.age_S3F2COMP_user.last_name'
 
-            (cast(t."user"."userid" as varchar)=m."queryablematchid" AND m."queryablecolumns"='user.userid'))
+                UNION ALL
+
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."user"."userid" as varchar)=m."queryablematchid" AND m."queryablecolumns"='user.userid'
+            )
         """
     )
 
@@ -258,16 +294,26 @@ def test_it_generates_query_with_simple_and_composite_matches():
     )
     assert escape_resp(resp) == escape_resp(
         """
-            SELECT DISTINCT t."$path"
-            FROM "amazonreviews"."amazon_reviews_parquet" t,
-                "s3f2_manifests_database"."s3f2_manifests_table" m
-            WHERE m."jobid"='job_1234567890'
-            AND m."datamapperid"='dm_1234' AND
+            SELECT DISTINCT "$path" FROM (
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    cast(t."a"."b"."c" as varchar)=m."queryablematchid" AND m."queryablecolumns"='a.b.c'
 
-            ((cast(t."a"."b"."c" as varchar)=m."queryablematchid" AND m."queryablecolumns"='a.b.c') OR
+                UNION ALL
 
-            (concat(t."user"."first_name", '_S3F2COMP_', t."user"."last_name")=m."queryablematchid" AND
-            m."queryablecolumns"='user.first_name_S3F2COMP_user.last_name'))
+                SELECT t."$path"
+                FROM "amazonreviews"."amazon_reviews_parquet" t,
+                    "s3f2_manifests_database"."s3f2_manifests_table" m
+                WHERE
+                    m."jobid"='job_1234567890' AND
+                    m."datamapperid"='dm_1234' AND
+                    concat(t."user"."first_name", '_S3F2COMP_', t."user"."last_name")=m."queryablematchid" AND
+                    m."queryablecolumns"='user.first_name_S3F2COMP_user.last_name'
+            )
         """
     )
 


### PR DESCRIPTION
*Description of changes:*
Current find query seems to induce pathological behavior in the query engine for data mappers with multiple column identifiers. We're seeing query runtimes of around 30 minutes for relatively small datasets. As an example, a data mapper with around 7 million rows for a given partition and 15000 match ids in the manifests table is taking around 30 minutes to run.

The cause seems to be the `OR` part of the query in particular. This PR significantly improves performance in this case by using unions instead. With this change, we're seeing query runtimes going from around 30 minutes to under 10 seconds. More details below.

### Original Query
```
SELECT DISTINCT t."$path"
    FROM db.table t,
        manifests m
    WHERE
        m."jobid"='xxx' AND
        m."datamapperid"='yyy' AND
        ((cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id') OR
        (cast(t."other_customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='other_customer_id'))
     AND "day" = '2021-05-06 00:00:00'
```
Result: 2 rows (Run time: 28 minutes 38 seconds, Data scanned: 84.31 MB)

### New Query

```
SELECT DISTINCT "$path" FROM (
    SELECT t."$path"
    FROM db.table t,
        manifests m
    WHERE
        m."jobid"='xxx' AND
        m."datamapperid"='yyy' AND
        cast(t."customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='customer_id'
         AND "day" = '2021-05-06 00:00:00'
    
    UNION ALL

    SELECT t."$path"
    FROM db.table t,
        manifests m
    WHERE
        m."jobid"='xxx' AND
        m."datamapperid"='yyy' AND
        cast(t."other_customer_id" as varchar)=m."queryablematchid" AND m."queryablecolumns"='other_customer_id'
         AND "day" = '2021-05-06 00:00:00'
)
```
Result: 2 rows (Run time: 6.52 seconds, Data scanned: 74.11 MB)

Below I included some specific information about the size of the data and manifests tables used in these queries to give an idea of the scale that is causing the issue.

### Data Table
```
select count(*) from db.table where day='2021-05-06 00:00:00'
```
Result: 7728147

### Manifests Table
```
select queryablecolumns, count(*) from manifests m
where m."jobid"='xxx' AND m."datamapperid"='yyy'
group by queryablecolumns
```
Result:
| queryablecolumns  | count |
|-------------------|-------|
| customer_id       | 7500  |
| other_customer_id | 7500  |

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
