### PR TITLE
Prevent duplicated query executions for long-running queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.42 (unreleased)
+
+- [#285](https://github.com/awslabs/amazon-s3-find-and-forget/pull/285): Fix for
+  a bug that caused a job to fail with a false positive
+  `The object s3://<REDACTED> was processed successfully but no rows required deletion`
+  when processing a job with queries running for more than 30m
+
 ## v0.41
 
 - [#283](https://github.com/awslabs/amazon-s3-find-and-forget/pull/283): Fix for

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -119,7 +119,6 @@ Resources:
   AthenaStateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: !Sub ${StateMachinePrefix}-AthenaStateMachine
       RoleArn: !GetAtt StatesExecutionRole.Arn
       DefinitionString: !Sub |-
         {
@@ -297,7 +296,6 @@ Resources:
   DeleteStateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: !Sub ${StateMachinePrefix}-DeletionStateMachine
       RoleArn: !GetAtt StatesExecutionRole.Arn
       DefinitionString: !Sub |-
         {
@@ -442,7 +440,6 @@ Resources:
   StateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: !Sub ${StateMachinePrefix}-StateMachine
       DefinitionString: !Sub |-
         {
           "Comment": "State machine for processing the S3 Find and Forget deletion queue.",
@@ -489,7 +486,7 @@ Resources:
                 "States": {
                   "Purge Query Queue": {
                     "Parameters": {
-                      "QueueUrl": "${QueryQueue}"
+                      "QueueUrl": "${QueryQ}"
                     },
                     "Comment": "Purge the query queue",
                     "Type": "Task",
@@ -722,7 +719,7 @@ Resources:
       RoleArn: !GetAtt StatesExecutionRole.Arn
 
   # Supporting Resources
-  QueryQueue:
+  QueryQ:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: alias/aws/sqs
@@ -742,7 +739,7 @@ Resources:
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
           Resource:
-          - !GetAtt QueryQueue.Arn
+          - !GetAtt QueryQ.Arn
           - !Sub
             - arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${QueueName}
             - QueueName: !Select [4, !Split ["/", !Ref DeleteQueueUrl]]
@@ -846,7 +843,7 @@ Resources:
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
           Resource:
-          - !GetAtt QueryQueue.Arn
+          - !GetAtt QueryQ.Arn
           - !Sub
             - arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${QueueName}
             - QueueName: !Select [4, !Split ["/", !Ref DeleteQueueUrl]]
@@ -859,7 +856,7 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
-          QueryQueue: !Ref QueryQueue
+          QueryQueue: !Ref QueryQ
       Policies:
       - S3CrudPolicy:
           BucketName: !Ref ManifestsBucket
@@ -893,7 +890,7 @@ Resources:
           - "sqs:SendMessage*"
           - "sqs:GetQueueAttributes"
           Resource:
-          - !GetAtt QueryQueue.Arn
+          - !GetAtt QueryQ.Arn
 
   OrchestrateECSServiceScaling:
     Type: AWS::Serverless::Function
@@ -915,7 +912,7 @@ Resources:
       Environment:
         Variables:
           StateMachineArn: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-AthenaStateMachine"
-          QueueUrl: !Ref QueryQueue
+          QueueUrl: !Ref QueryQ
       Policies:
       - S3CrudPolicy:
           BucketName: !Ref ResultBucket
@@ -935,7 +932,7 @@ Resources:
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
           Resource:
-          - !GetAtt QueryQueue.Arn
+          - !GetAtt QueryQ.Arn
 
   DeleteQueueMessage:
     Type: AWS::Serverless::Function
@@ -944,14 +941,14 @@ Resources:
       CodeUri: ../backend/lambdas/tasks/
       Environment:
         Variables:
-          QueueUrl: !Ref QueryQueue
+          QueueUrl: !Ref QueryQ
       Policies:
       - Statement:
         - Action:
           - "sqs:DeleteMessage"
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
-          Resource: !GetAtt QueryQueue.Arn
+          Resource: !GetAtt QueryQ.Arn
 
   PurgeQueue:
     Type: AWS::Serverless::Function
@@ -965,7 +962,7 @@ Resources:
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
           Resource:
-          - !GetAtt QueryQueue.Arn
+          - !GetAtt QueryQ.Arn
           - !Sub
             - arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${QueueName}
             - QueueName: !Select [4, !Split ["/", !Ref DeleteQueueUrl]]
@@ -1022,7 +1019,7 @@ Outputs:
   GenerateQueriesRole:
     Value: !Ref GenerateQueriesRole
   QueryQueueUrl:
-    Value: !Ref QueryQueue
+    Value: !Ref QueryQ
   StateMachineArn:
     Value: !Ref StateMachine
   StateMachineRoleArn:

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -719,7 +719,9 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: alias/aws/sqs
-      VisibilityTimeout: 1800
+      VisibilityTimeout: 43200
+      ContentBasedDeduplication: true
+      FifoQueue: true
 
   # Tasks
   CheckQueueSize:

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -116,10 +116,10 @@ Resources:
               - "states:StartExecution"
             Resource: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}*"
 
-  QueryStateMachine:
+  AthenaStateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: !Sub ${StateMachinePrefix}-QueryStateMachine
+      StateMachineName: !Sub ${StateMachinePrefix}-AthenaStateMachine
       RoleArn: !GetAtt StatesExecutionRole.Arn
       DefinitionString: !Sub |-
         {
@@ -294,10 +294,10 @@ Resources:
           }
         }
 
-  ForgetStateMachine:
+  DeleteStateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: !Sub ${StateMachinePrefix}-ForgetStateMachine
+      StateMachineName: !Sub ${StateMachinePrefix}-DeletionStateMachine
       RoleArn: !GetAtt StatesExecutionRole.Arn
       DefinitionString: !Sub |-
         {
@@ -489,7 +489,7 @@ Resources:
                 "States": {
                   "Purge Query Queue": {
                     "Parameters": {
-                      "QueueUrl": "${QueryQ}"
+                      "QueueUrl": "${QueryQueue}"
                     },
                     "Comment": "Purge the query queue",
                     "Type": "Task",
@@ -651,7 +651,7 @@ Resources:
                   "DeletionTasksMaxNumber.$": "$.DeletionTasksMaxNumber",
                   "WaitDuration.$": "$.ForgetQueueWaitSeconds"
                 },
-                "StateMachineArn":"${ForgetStateMachine}",
+                "StateMachineArn":"${DeleteStateMachine}",
                 "Name.$": "$$.Execution.Name"
               },
               "ResultPath": null,
@@ -722,13 +722,11 @@ Resources:
       RoleArn: !GetAtt StatesExecutionRole.Arn
 
   # Supporting Resources
-  QueryQ:
+  QueryQueue:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: alias/aws/sqs
       VisibilityTimeout: 43200
-      ContentBasedDeduplication: true
-      FifoQueue: true
 
   # Tasks
   CheckQueueSize:
@@ -742,7 +740,7 @@ Resources:
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
           Resource:
-          - !GetAtt QueryQ.Arn
+          - !GetAtt QueryQueue.Arn
           - !Sub
             - arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${QueueName}
             - QueueName: !Select [4, !Split ["/", !Ref DeleteQueueUrl]]
@@ -846,7 +844,7 @@ Resources:
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
           Resource:
-          - !GetAtt QueryQ.Arn
+          - !GetAtt QueryQueue.Arn
           - !Sub
             - arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${QueueName}
             - QueueName: !Select [4, !Split ["/", !Ref DeleteQueueUrl]]
@@ -859,7 +857,7 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
-          QueryQueue: !Ref QueryQ
+          QueryQueue: !Ref QueryQueue
       Policies:
       - S3CrudPolicy:
           BucketName: !Ref ManifestsBucket
@@ -893,7 +891,7 @@ Resources:
           - "sqs:SendMessage*"
           - "sqs:GetQueueAttributes"
           Resource:
-          - !GetAtt QueryQ.Arn
+          - !GetAtt QueryQueue.Arn
 
   OrchestrateECSServiceScaling:
     Type: AWS::Serverless::Function
@@ -914,8 +912,8 @@ Resources:
       CodeUri: ../backend/lambdas/tasks/
       Environment:
         Variables:
-          StateMachineArn: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-QueryStateMachine"
-          QueueUrl: !Ref QueryQ
+          StateMachineArn: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-AthenaStateMachine"
+          QueueUrl: !Ref QueryQueue
       Policies:
       - S3CrudPolicy:
           BucketName: !Ref ResultBucket
@@ -925,8 +923,8 @@ Resources:
           - "states:DescribeExecution"
           Effect: Allow
           Resource:
-          - !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-QueryStateMachine"
-          - !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${StateMachinePrefix}-QueryStateMachine:*"
+          - !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-AthenaStateMachine"
+          - !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${StateMachinePrefix}-AthenaStateMachine:*"
         - Action:
           - "sqs:ReceiveMessage*"
           - "sqs:ChangeMessageVisibility"
@@ -935,7 +933,7 @@ Resources:
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
           Resource:
-          - !GetAtt QueryQ.Arn
+          - !GetAtt QueryQueue.Arn
 
   DeleteQueueMessage:
     Type: AWS::Serverless::Function
@@ -944,14 +942,14 @@ Resources:
       CodeUri: ../backend/lambdas/tasks/
       Environment:
         Variables:
-          QueueUrl: !Ref QueryQ
+          QueueUrl: !Ref QueryQueue
       Policies:
       - Statement:
         - Action:
           - "sqs:DeleteMessage"
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
-          Resource: !GetAtt QueryQ.Arn
+          Resource: !GetAtt QueryQueue.Arn
 
   PurgeQueue:
     Type: AWS::Serverless::Function
@@ -965,7 +963,7 @@ Resources:
           - "sqs:GetQueueAttributes"
           Effect: "Allow"
           Resource:
-          - !GetAtt QueryQ.Arn
+          - !GetAtt QueryQueue.Arn
           - !Sub
             - arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${QueueName}
             - QueueName: !Select [4, !Split ["/", !Ref DeleteQueueUrl]]
@@ -1018,11 +1016,11 @@ Outputs:
   AthenaExecutionRoleArn:
     Value: !GetAtt ExecuteQueryRole.Arn
   AthenaStateMachineArn:
-    Value: !Ref QueryStateMachine
+    Value: !Ref AthenaStateMachine
   GenerateQueriesRole:
     Value: !Ref GenerateQueriesRole
   QueryQueueUrl:
-    Value: !Ref QueryQ
+    Value: !Ref QueryQueue
   StateMachineArn:
     Value: !Ref MainStateMachine
   StateMachineRoleArn:

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -116,9 +116,10 @@ Resources:
               - "states:StartExecution"
             Resource: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}*"
 
-  AthenaStateMachine:
+  QueryStateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
+      StateMachineName: !Sub ${StateMachinePrefix}-QueryStateMachine
       RoleArn: !GetAtt StatesExecutionRole.Arn
       DefinitionString: !Sub |-
         {
@@ -293,9 +294,10 @@ Resources:
           }
         }
 
-  DeleteStateMachine:
+  ForgetStateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
+      StateMachineName: !Sub ${StateMachinePrefix}-ForgetStateMachine
       RoleArn: !GetAtt StatesExecutionRole.Arn
       DefinitionString: !Sub |-
         {
@@ -437,9 +439,10 @@ Resources:
           }
         }
 
-  StateMachine:
+  MainStateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
+      StateMachineName: !Sub ${StateMachinePrefix}-MainStateMachine
       DefinitionString: !Sub |-
         {
           "Comment": "State machine for processing the S3 Find and Forget deletion queue.",
@@ -648,7 +651,7 @@ Resources:
                   "DeletionTasksMaxNumber.$": "$.DeletionTasksMaxNumber",
                   "WaitDuration.$": "$.ForgetQueueWaitSeconds"
                 },
-                "StateMachineArn":"${DeleteStateMachine}",
+                "StateMachineArn":"${ForgetStateMachine}",
                 "Name.$": "$$.Execution.Name"
               },
               "ResultPath": null,
@@ -911,7 +914,7 @@ Resources:
       CodeUri: ../backend/lambdas/tasks/
       Environment:
         Variables:
-          StateMachineArn: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-AthenaStateMachine"
+          StateMachineArn: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-QueryStateMachine"
           QueueUrl: !Ref QueryQ
       Policies:
       - S3CrudPolicy:
@@ -922,8 +925,8 @@ Resources:
           - "states:DescribeExecution"
           Effect: Allow
           Resource:
-          - !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-AthenaStateMachine"
-          - !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${StateMachinePrefix}-AthenaStateMachine:*"
+          - !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-QueryStateMachine"
+          - !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${StateMachinePrefix}-QueryStateMachine:*"
         - Action:
           - "sqs:ReceiveMessage*"
           - "sqs:ChangeMessageVisibility"
@@ -985,7 +988,7 @@ Resources:
           - "aws.states"
         detail:
           stateMachineArn:
-            - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-StateMachine
+            - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-MainStateMachine
           status:
             - "ABORTED"
             - "TIMED_OUT"
@@ -1015,12 +1018,12 @@ Outputs:
   AthenaExecutionRoleArn:
     Value: !GetAtt ExecuteQueryRole.Arn
   AthenaStateMachineArn:
-    Value: !Ref AthenaStateMachine
+    Value: !Ref QueryStateMachine
   GenerateQueriesRole:
     Value: !Ref GenerateQueriesRole
   QueryQueueUrl:
     Value: !Ref QueryQ
   StateMachineArn:
-    Value: !Ref StateMachine
+    Value: !Ref MainStateMachine
   StateMachineRoleArn:
     Value: !GetAtt StatesExecutionRole.Arn

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -439,10 +439,10 @@ Resources:
           }
         }
 
-  MainStateMachine:
+  StateMachine:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: !Sub ${StateMachinePrefix}-MainStateMachine
+      StateMachineName: !Sub ${StateMachinePrefix}-StateMachine
       DefinitionString: !Sub |-
         {
           "Comment": "State machine for processing the S3 Find and Forget deletion queue.",
@@ -986,7 +986,7 @@ Resources:
           - "aws.states"
         detail:
           stateMachineArn:
-            - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-MainStateMachine
+            - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StateMachinePrefix}-StateMachine
           status:
             - "ABORTED"
             - "TIMED_OUT"
@@ -1022,6 +1022,6 @@ Outputs:
   QueryQueueUrl:
     Value: !Ref QueryQueue
   StateMachineArn:
-    Value: !Ref MainStateMachine
+    Value: !Ref StateMachine
   StateMachineRoleArn:
     Value: !GetAtt StatesExecutionRole.Arn

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -205,7 +205,7 @@ Resources:
       - DelStack
       - DeployStack
       - LayersStack
-      - StateMachineStack
+      - SMStack
       - StreamProcessorStack
       - WebUIStack
     Properties:
@@ -278,7 +278,7 @@ Resources:
       TemplateURL: ./deployment_helper.yaml
       Parameters:
         ApiUrl: !GetAtt APIStack.Outputs.ApiUrl
-        AthenaExecutionRole: !GetAtt StateMachineStack.Outputs.AthenaExecutionRole
+        AthenaExecutionRole: !GetAtt SMStack.Outputs.AthenaExecutionRole
         CloudFrontDistribution: !GetAtt WebUIStack.Outputs.CloudFrontDistribution
         CodeBuildArtefactBucket: !Ref TempBucket
         CognitoIdentityPoolId: !GetAtt AuthStack.Outputs.CognitoIdentityPoolId
@@ -305,7 +305,7 @@ Resources:
       TemplateURL: ./manifests.yaml
       Parameters:
         JobDetailsRetentionDays: !Ref JobDetailsRetentionDays
-  StateMachineStack:
+  SMStack:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: ./state_machine.yaml
@@ -344,7 +344,7 @@ Resources:
         JobTableName: !GetAtt DDBStack.Outputs.JobTable
         JobTableStreamArn: !GetAtt DDBStack.Outputs.JobTableStreamArn
         ManifestsBucket: !GetAtt ManifestsStack.Outputs.ManifestsBucket
-        StateMachineArn: !GetAtt StateMachineStack.Outputs.StateMachineArn
+        StateMachineArn: !GetAtt SMStack.Outputs.StateMachineArn
   VpcStack:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldDeployVpc
@@ -373,9 +373,9 @@ Outputs:
     Export:
       Name: !Sub ${ResourcePrefix}-ApiUrl
   AthenaStateMachineArn:
-    Value: !GetAtt StateMachineStack.Outputs.AthenaStateMachineArn
+    Value: !GetAtt SMStack.Outputs.AthenaStateMachineArn
   AthenaExecutionRoleArn:
-    Value: !GetAtt StateMachineStack.Outputs.AthenaExecutionRoleArn
+    Value: !GetAtt SMStack.Outputs.AthenaExecutionRoleArn
   ConfigParameter:
     Value: !Ref ConfigParameter
   CognitoUserPoolClientId:
@@ -403,7 +403,7 @@ Outputs:
   ECRRepository:
     Value: !GetAtt DelStack.Outputs.ECRRepository
   GenerateQueriesRole:
-    Value: !GetAtt StateMachineStack.Outputs.GenerateQueriesRole
+    Value: !GetAtt SMStack.Outputs.GenerateQueriesRole
   JobTable:
     Value: !GetAtt DDBStack.Outputs.JobTable
   KMSKeyArns:
@@ -411,13 +411,13 @@ Outputs:
   PutDataMapperRole:
     Value: !GetAtt APIStack.Outputs.PutDataMapperRole
   QueryQueueUrl:
-    Value: !GetAtt StateMachineStack.Outputs.QueryQueueUrl
+    Value: !GetAtt SMStack.Outputs.QueryQueueUrl
   SolutionVersion:
     Value: !FindInMap [Solution, Constants, Version]
   StateMachineArn:
-    Value: !GetAtt StateMachineStack.Outputs.StateMachineArn
+    Value: !GetAtt SMStack.Outputs.StateMachineArn
   StateMachineRoleArn:
-    Value: !GetAtt StateMachineStack.Outputs.StateMachineRoleArn
+    Value: !GetAtt SMStack.Outputs.StateMachineRoleArn
   TempBucket:
     Value: !Ref TempBucket
   WebUIBucket:

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -205,7 +205,7 @@ Resources:
       - DelStack
       - DeployStack
       - LayersStack
-      - SMStack
+      - StateMachineStack
       - StreamProcessorStack
       - WebUIStack
     Properties:
@@ -278,7 +278,7 @@ Resources:
       TemplateURL: ./deployment_helper.yaml
       Parameters:
         ApiUrl: !GetAtt APIStack.Outputs.ApiUrl
-        AthenaExecutionRole: !GetAtt SMStack.Outputs.AthenaExecutionRole
+        AthenaExecutionRole: !GetAtt StateMachineStack.Outputs.AthenaExecutionRole
         CloudFrontDistribution: !GetAtt WebUIStack.Outputs.CloudFrontDistribution
         CodeBuildArtefactBucket: !Ref TempBucket
         CognitoIdentityPoolId: !GetAtt AuthStack.Outputs.CognitoIdentityPoolId
@@ -305,7 +305,7 @@ Resources:
       TemplateURL: ./manifests.yaml
       Parameters:
         JobDetailsRetentionDays: !Ref JobDetailsRetentionDays
-  SMStack:
+  StateMachineStack:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: ./state_machine.yaml
@@ -344,7 +344,7 @@ Resources:
         JobTableName: !GetAtt DDBStack.Outputs.JobTable
         JobTableStreamArn: !GetAtt DDBStack.Outputs.JobTableStreamArn
         ManifestsBucket: !GetAtt ManifestsStack.Outputs.ManifestsBucket
-        StateMachineArn: !GetAtt SMStack.Outputs.StateMachineArn
+        StateMachineArn: !GetAtt StateMachineStack.Outputs.StateMachineArn
   VpcStack:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldDeployVpc
@@ -373,9 +373,9 @@ Outputs:
     Export:
       Name: !Sub ${ResourcePrefix}-ApiUrl
   AthenaStateMachineArn:
-    Value: !GetAtt SMStack.Outputs.AthenaStateMachineArn
+    Value: !GetAtt StateMachineStack.Outputs.AthenaStateMachineArn
   AthenaExecutionRoleArn:
-    Value: !GetAtt SMStack.Outputs.AthenaExecutionRoleArn
+    Value: !GetAtt StateMachineStack.Outputs.AthenaExecutionRoleArn
   ConfigParameter:
     Value: !Ref ConfigParameter
   CognitoUserPoolClientId:
@@ -403,7 +403,7 @@ Outputs:
   ECRRepository:
     Value: !GetAtt DelStack.Outputs.ECRRepository
   GenerateQueriesRole:
-    Value: !GetAtt SMStack.Outputs.GenerateQueriesRole
+    Value: !GetAtt StateMachineStack.Outputs.GenerateQueriesRole
   JobTable:
     Value: !GetAtt DDBStack.Outputs.JobTable
   KMSKeyArns:
@@ -411,13 +411,13 @@ Outputs:
   PutDataMapperRole:
     Value: !GetAtt APIStack.Outputs.PutDataMapperRole
   QueryQueueUrl:
-    Value: !GetAtt SMStack.Outputs.QueryQueueUrl
+    Value: !GetAtt StateMachineStack.Outputs.QueryQueueUrl
   SolutionVersion:
     Value: !FindInMap [Solution, Constants, Version]
   StateMachineArn:
-    Value: !GetAtt SMStack.Outputs.StateMachineArn
+    Value: !GetAtt StateMachineStack.Outputs.StateMachineArn
   StateMachineRoleArn:
-    Value: !GetAtt SMStack.Outputs.StateMachineRoleArn
+    Value: !GetAtt StateMachineStack.Outputs.StateMachineRoleArn
   TempBucket:
     Value: !Ref TempBucket
   WebUIBucket:


### PR DESCRIPTION
*Description of changes:*

The query queue SQS currently has a visibility timeout of 30m, which is the default timeout for Athena queries.
If a customer requests an increase and a query takes more than 30m, a new query will start and possibly result on duplicating results in the deletion SQS queue (we have deduplication there being FIFO, but that is only based on timeframes of approximately 5m). As a result, the Forget phase will have some tasks working on the same object, with the first successfully deleting, and the next failing with an error like: `Unprocessable message: The object s3://<REDACTED> was processed successfully but no rows required deletion`.

I initially thought of solving the issue by making the visibility timeout configurable, but I then thought that there are possibly no scenarios where I want the query to be retried after getting back to the SQS queue, as we [recently built the retry mechanism handling the retry within the Athena step function](https://github.com/awslabs/amazon-s3-find-and-forget/pull/272) and therefore we already have a circuit breaker for the athena failures. 

*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
