### PR TITLE
Add retries to state machine, Respect AthenaQueryMaxRetries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.42 (unreleased)
 
+- [#286](https://github.com/awslabs/amazon-s3-find-and-forget/pull/286): Make
+  state machine more resilient to transient failures by adding retry
+
 - [#284](https://github.com/awslabs/amazon-s3-find-and-forget/pull/284): Improve
   performance of find query for data mappers with multiple column identifiers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.42 (unreleased)
 
+- [#286](https://github.com/awslabs/amazon-s3-find-and-forget/pull/286): Fix for
+  a bug that causes `AthenaQueryMaxRetries` setting to be ignored
+
 - [#286](https://github.com/awslabs/amazon-s3-find-and-forget/pull/286): Make
   state machine more resilient to transient failures by adding retry
 

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -159,6 +159,12 @@ Resources:
               "Type": "Task",
               "Resource": "${CheckQueryStatus.Arn}",
               "Next": "Query Complete?",
+              "Retry": [{
+                 "ErrorEquals": [ "States.ALL" ],
+                 "IntervalSeconds": 10,
+                 "BackoffRate": 10,
+                 "MaxAttempts": 2
+              }],
               "Catch": [{
                  "ErrorEquals": ["States.ALL"],
                  "ResultPath": "$.ErrorDetails",

--- a/templates/state_machine.yaml
+++ b/templates/state_machine.yaml
@@ -454,6 +454,7 @@ Resources:
                 "ExecutionId.$": "$$.Execution.Id",
                 "ExecutionName.$": "$$.Execution.Name",
                 "AthenaConcurrencyLimit.$": "$.AthenaConcurrencyLimit",
+                "AthenaQueryMaxRetries.$": "$.AthenaQueryMaxRetries",
                 "DeletionTasksMaxNumber.$": "$.DeletionTasksMaxNumber",
                 "ForgetQueueWaitSeconds.$": "$.ForgetQueueWaitSeconds",
                 "QueryExecutionWaitSeconds.$": "$.QueryExecutionWaitSeconds",


### PR DESCRIPTION
*Description of changes:*
2 small changes:
1. `AthenaQueryMaxRetries` parameter was being ignored since it wasn't being picked out in the initial Pass state of the state machine. Added it to the list of parameters.
2. Athena state machine failure was causing job to fail due to transient errors such as the following. Added retry to one of the steps to avoid this issue.
```
{
  "error": "Lambda.SdkClientException",
  "cause": "Unable to execute HTTP request: Connection reset"
}
```

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
