### PR TITLE
Add parameter for ignoring Object Not Found exceptions during deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.43 (unreleased)
+
+- [#287](https://github.com/awslabs/amazon-s3-find-and-forget/pull/287): Add
+  data mapper parameter for ignoring Object Not Found exceptions encountered
+  during deletion
+
 ## v0.42
 
 - [#285](https://github.com/awslabs/amazon-s3-find-and-forget/pull/285): Fix for

--- a/backend/ecs_tasks/delete_files/events.py
+++ b/backend/ecs_tasks/delete_files/events.py
@@ -20,6 +20,15 @@ def emit_deletion_event(message_body, stats):
     emit_event(job_id, "ObjectUpdated", event_data, get_emitter_id())
 
 
+def emit_skipped_event(message_body, skip_reason):
+    job_id = message_body["JobId"]
+    event_data = {
+        "Object": message_body["Object"],
+        "Reason": skip_reason,
+    }
+    emit_event(job_id, "ObjectUpdateSkipped", event_data, get_emitter_id())
+
+
 def emit_failure_event(message_body, err_message, event_name):
     json_body = json.loads(message_body)
     job_id = json_body.get("JobId")

--- a/backend/lambdas/data_mappers/handlers.py
+++ b/backend/lambdas/data_mappers/handlers.py
@@ -83,6 +83,9 @@ def put_data_mapper_handler(event, context):
         "RoleArn": body["RoleArn"],
         "Format": body.get("Format", "parquet"),
         "DeleteOldVersions": body.get("DeleteOldVersions", True),
+        "IgnoreObjectNotFoundExceptions": body.get(
+            "IgnoreObjectNotFoundExceptions", False
+        ),
     }
     table.put_item(Item=item)
 

--- a/backend/lambdas/jobs/handlers.py
+++ b/backend/lambdas/jobs/handlers.py
@@ -38,6 +38,7 @@ job_summary_attributes = [
     "JobStartTime",
     "TotalObjectRollbackFailedCount",
     "TotalObjectUpdatedCount",
+    "TotalObjectUpdateSkippedCount",
     "TotalObjectUpdateFailedCount",
     "TotalQueryCount",
     "TotalQueryFailedCount",

--- a/backend/lambdas/jobs/stats_updater.py
+++ b/backend/lambdas/jobs/stats_updater.py
@@ -47,6 +47,7 @@ def _aggregate_stats(events):
             )
         if event_name in [
             "ObjectUpdated",
+            "ObjectUpdateSkipped",
             "ObjectUpdateFailed",
             "ObjectRollbackFailed",
         ]:
@@ -54,6 +55,9 @@ def _aggregate_stats(events):
                 {
                     "TotalObjectUpdatedCount": 1
                     if event_name == "ObjectUpdated"
+                    else 0,
+                    "TotalObjectUpdateSkippedCount": 1
+                    if event_name == "ObjectUpdateSkipped"
                     else 0,
                     "TotalObjectUpdateFailedCount": 1
                     if event_name == "ObjectUpdateFailed"
@@ -78,6 +82,7 @@ def _update_job(job_id, stats):
             "#qb = if_not_exists(#qb, :z) + :qb, "
             "#qm = if_not_exists(#qm, :z) + :qm, "
             "#ou = if_not_exists(#ou, :z) + :ou, "
+            "#os = if_not_exists(#os, :z) + :os, "
             "#of = if_not_exists(#of, :z) + :of, "
             "#or = if_not_exists(#or, :z) + :or",
             ExpressionAttributeNames={
@@ -89,6 +94,7 @@ def _update_job(job_id, stats):
                 "#qb": "TotalQueryScannedInBytes",
                 "#qm": "TotalQueryTimeInMillis",
                 "#ou": "TotalObjectUpdatedCount",
+                "#os": "TotalObjectUpdateSkippedCount",
                 "#of": "TotalObjectUpdateFailedCount",
                 "#or": "TotalObjectRollbackFailedCount",
             },
@@ -101,6 +107,7 @@ def _update_job(job_id, stats):
                 ":qb": stats.get("TotalQueryScannedInBytes", 0),
                 ":qm": stats.get("TotalQueryTimeInMillis", 0),
                 ":ou": stats.get("TotalObjectUpdatedCount", 0),
+                ":os": stats.get("TotalObjectUpdateSkippedCount", 0),
                 ":of": stats.get("TotalObjectUpdateFailedCount", 0),
                 ":or": stats.get("TotalObjectRollbackFailedCount", 0),
                 ":z": 0,

--- a/backend/lambdas/tasks/generate_queries.py
+++ b/backend/lambdas/tasks/generate_queries.py
@@ -154,6 +154,9 @@ def generate_athena_queries(data_mapper, deletion_items, job_id):
         "Columns": columns,
         "PartitionKeys": [],
         "DeleteOldVersions": data_mapper.get("DeleteOldVersions", True),
+        "IgnoreObjectNotFoundExceptions": data_mapper.get(
+            "IgnoreObjectNotFoundExceptions", False
+        ),
     }
     if data_mapper.get("RoleArn", None):
         msg["RoleArn"] = data_mapper["RoleArn"]

--- a/backend/lambdas/tasks/submit_query_results.py
+++ b/backend/lambdas/tasks/submit_query_results.py
@@ -39,6 +39,9 @@ def handler(event, context):
             "Columns": event["Columns"],
             "RoleArn": event.get("RoleArn", None),
             "DeleteOldVersions": event.get("DeleteOldVersions", True),
+            "IgnoreObjectNotFoundExceptions": event.get(
+                "IgnoreObjectNotFoundExceptions", False
+            ),
             "Format": event.get("Format"),
             "Manifest": event.get("Manifest"),
         }

--- a/docs/LIMITS.md
+++ b/docs/LIMITS.md
@@ -69,6 +69,10 @@ supported:
   that reads from the data lake unless it has been designed to handle temporary
   inconsistencies between objects
 - Buckets with MFA Delete enabled are not supported
+- When the _Ignore object not found exceptions during deletion_ setting is
+  enabled, the solution will not delete old versions for ignored objects. Make
+  sure there is some mechanism for deleting these old versions to avoid
+  **retaining data longer than intended**.
 
 ## Service Quotas
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -436,8 +436,19 @@ To grant these permissions in Lake Formation:
    latest created object version, deselect _Delete previous object versions
    after update_. By default the solution will delete all previous of versions
    after creating a new version.
-9. Choose **Create Data Mapper**.
-10. A message is displayed advising you to update the S3 Bucket Policy for the
+9. If you want the solution to ignore Object Not Found exceptions, select
+   _Ignore object not found exceptions during deletion_. By default deletion
+   jobs will fail if any objects that are found by the Find phase don't exist in
+   the Delete phase. This setting can be useful if you have some other system
+   deleting objects from the bucket, for example S3 lifecycle policies.
+
+   Note that the solution **will not** delete old versions for these objects.
+   This can cause data to be **retained longer than intended**. Make sure there
+   is some mechanism to handle old versions. One option would be to configure
+   [S3 lifecycle policies] on non-current versions.
+
+10. Choose **Create Data Mapper**.
+11. A message is displayed advising you to update the S3 Bucket Policy for the
     S3 Bucket referenced by the newly created data mapper. See
     [Granting Access to Data](#granting-access-to-data) for more information on
     how to do this. Choose **Return to Data Mappers**.
@@ -888,3 +899,5 @@ To delete a stack via the AWS CLI
   https://docs.aws.amazon.com/lake-formation/latest/dg/granting-catalog-permissions.html
 [exporting stack output values]:
   https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-exports.html
+[s3 lifecycle policies]:
+  https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html

--- a/docs/api/Models/DataMapper.md
+++ b/docs/api/Models/DataMapper.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **QueryExecutorParameters** | [**DataMapper_QueryExecutorParameters**](DataMapper_QueryExecutorParameters.md) |  | [default to null]
 **RoleArn** | [**String**](string.md) | Role ARN to assume when performing operations in S3 for this data mapper. The role must have the exact name &#39;S3F2DataAccessRole&#39;. | [default to null]
 **DeleteOldVersions** | [**Boolean**](boolean.md) | Toggles deleting all non-latest versions of an object after a new redacted version is created | [optional] [default to true]
+**IgnoreObjectNotFoundExceptions** | [**Boolean**](boolean.md) | Toggles ignoring Object Not Found errors during deletion | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/api/Models/Job.md
+++ b/docs/api/Models/Job.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **QueryExecutionWaitSeconds** | [**Integer**](integer.md) | Query execution wait setting for this job | [default to null]
 **QueryQueueWaitSeconds** | [**Integer**](integer.md) | Query queue worker wait setting for this job | [default to null]
 **TotalObjectUpdatedCount** | [**Integer**](integer.md) | Total number of successfully updated objects | [optional] [default to 0]
+**TotalObjectUpdateSkippedCount** | [**Integer**](integer.md) | Total number of skipped objects | [optional] [default to 0]
 **TotalObjectUpdateFailedCount** | [**Integer**](integer.md) | Total number of objects which could not be successfully updated | [optional] [default to 0]
 **TotalObjectRollbackFailedCount** | [**Integer**](integer.md) | Total number of objects which could not be successfully rolled back after detecting an integrity conflict | [optional] [default to 0]
 **TotalQueryCount** | [**Integer**](integer.md) | Total number of queries executed during the find phase | [optional] [default to 0]

--- a/docs/api/Models/JobSummary.md
+++ b/docs/api/Models/JobSummary.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **JobStartTime** | [**Integer**](integer.md) | Job start date as Epoch timestamp | [optional] [default to null]
 **JobFinishTime** | [**Integer**](integer.md) | Job finish date as Epoch timestamp | [optional] [default to null]
 **TotalObjectUpdatedCount** | [**Integer**](integer.md) | Total number of successfully updated objects | [optional] [default to 0]
+**TotalObjectUpdateSkippedCount** | [**Integer**](integer.md) | Total number of skipped objects | [optional] [default to 0]
 **TotalObjectUpdateFailedCount** | [**Integer**](integer.md) | Total number of objects which could not be successfully updated | [optional] [default to 0]
 **TotalObjectRollbackFailedCount** | [**Integer**](integer.md) | Total number of objects which could not be successfully rolled back after detecting an integrity conflict | [optional] [default to 0]
 **TotalQueryCount** | [**Integer**](integer.md) | Total number of queries executed during the find phase | [optional] [default to 0]

--- a/frontend/src/components/pages/DeletionJob.js
+++ b/frontend/src/components/pages/DeletionJob.js
@@ -280,6 +280,9 @@ const DeletionJob = ({ gateway, jobId }) => {
             <DetailsBox label="Total Object Updated Count" noSeparator>
               {withDefault(job.TotalObjectUpdatedCount)}
             </DetailsBox>
+            <DetailsBox label="Total Object Update Skipped Count" noSeparator>
+              {withDefault(job.TotalObjectUpdateSkippedCount)}
+            </DetailsBox>
             <DetailsBox
               label="Total Object Update Failed Count"
               className={`status-label ${errorCountClass(

--- a/frontend/src/components/pages/NewDataMapper.js
+++ b/frontend/src/components/pages/NewDataMapper.js
@@ -97,6 +97,7 @@ const NewDataMapper = ({ gateway, goToDataMappers }) => {
   const [glueTable, setGlueTable] = useState(undefined);
   const [roleArn, setRoleArn] = useState(undefined);
   const [deletePreviousVersions, setDeletePreviousVersions] = useState(true);
+  const [ignoreObjectNotFoundExceptions, setIgnoreObjectNotFoundExceptions] = useState(false);
   const [submitClicked, setSubmitClicked] = useState(false);
 
   const validationAttributes = (isValid) =>
@@ -156,6 +157,7 @@ const NewDataMapper = ({ gateway, goToDataMappers }) => {
           partitionKeys,
           roleArn,
           deletePreviousVersions,
+          ignoreObjectNotFoundExceptions,
           selectedTable.format
         );
         setFormState("saved");
@@ -404,6 +406,18 @@ const NewDataMapper = ({ gateway, goToDataMappers }) => {
                   label="Delete previous object versions after update"
                   onChange={(e) =>
                     setDeletePreviousVersions(!deletePreviousVersions)
+                  }
+                />
+              </Form.Group>
+              <Form.Group>
+                <Form.Check
+                  type="checkbox"
+                  id="ignore-object-not-found-exceptions"
+                  name="column"
+                  checked={ignoreObjectNotFoundExceptions}
+                  label="Ignore object not found exceptions during deletion"
+                  onChange={(e) =>
+                    setIgnoreObjectNotFoundExceptions(!ignoreObjectNotFoundExceptions)
                   }
                 />
               </Form.Group>

--- a/frontend/src/utils/gateway.js
+++ b/frontend/src/utils/gateway.js
@@ -177,6 +177,7 @@ const gateway = {
     partitionKeys,
     roleArn,
     deleteOldVersions,
+    ignoreObjectNotFoundExceptions,
     format
   ) {
     return apiGateway(`data_mappers/${id}`, {
@@ -193,7 +194,8 @@ const gateway = {
         },
         Format: format,
         RoleArn: roleArn,
-        DeleteOldVersions: deleteOldVersions
+        DeleteOldVersions: deleteOldVersions,
+        IgnoreObjectNotFoundExceptions: ignoreObjectNotFoundExceptions
       }
     });
   }

--- a/templates/api.definition.yml
+++ b/templates/api.definition.yml
@@ -522,6 +522,10 @@ components:
           type: "boolean"
           description: "Toggles deleting all non-latest versions of an object after a new redacted version is created"
           default: "true"
+        IgnoreObjectNotFoundExceptions:
+          type: "boolean"
+          description: "Toggles ignoring Object Not Found errors during deletion"
+          default: "false"
     DeletionQueueItem:
       description: "A Deletion Queue Item object"
       type: "object"
@@ -642,6 +646,10 @@ components:
           type: "integer"
           description: "Total number of successfully updated objects"
           default: 0
+        TotalObjectUpdateSkippedCount:
+          type: "integer"
+          description: "Total number of skipped objects"
+          default: 0
         TotalObjectUpdateFailedCount:
           type: "integer"
           description: "Total number of objects which could not be successfully updated"
@@ -735,6 +743,10 @@ components:
         TotalObjectUpdatedCount:
           type: "integer"
           description: "Total number of successfully updated objects"
+          default: 0
+        TotalObjectUpdateSkippedCount:
+          type: "integer"
+          description: "Total number of skipped objects"
           default: 0
         TotalObjectUpdateFailedCount:
           type: "integer"

--- a/tests/acceptance/test_data_mappers.py
+++ b/tests/acceptance/test_data_mappers.py
@@ -47,6 +47,7 @@ def test_it_creates_data_mapper(
         "Format": "parquet",
         "RoleArn": "arn:aws:iam::123456789012:role/S3F2DataAccessRole",
         "DeleteOldVersions": False,
+        "IgnoreObjectNotFoundExceptions": True,
     }
     # Act
     response = api_client.put(
@@ -93,6 +94,7 @@ def test_it_modifies_data_mapper(
         "Format": "parquet",
         "RoleArn": "arn:aws:iam::123456789012:role/S3F2DataAccessRole",
         "DeleteOldVersions": False,
+        "IgnoreObjectNotFoundExceptions": False,
     }
     # Act
     create_response = api_client.put(
@@ -148,6 +150,7 @@ def test_it_creates_without_optionals(
         "Sub": mock.ANY,
     }
     expected["DeleteOldVersions"] = True
+    expected["IgnoreObjectNotFoundExceptions"] = False
     # Check the response is ok
     assert 201 == response.status_code
     assert expected == response_body

--- a/tests/unit/data_mappers/test_data_mappers.py
+++ b/tests/unit/data_mappers/test_data_mappers.py
@@ -65,6 +65,7 @@ def test_it_creates_data_mapper(validate_mapper, table):
                     "Format": "parquet",
                     "RoleArn": "arn:aws:iam::accountid:role/S3F2DataAccessRole",
                     "DeleteOldVersions": False,
+                    "IgnoreObjectNotFoundExceptions": True,
                 }
             ),
             "requestContext": autorization_mock,
@@ -86,6 +87,7 @@ def test_it_creates_data_mapper(validate_mapper, table):
         "CreatedBy": {"Username": "cognitoUsername", "Sub": "cognitoSub"},
         "RoleArn": "arn:aws:iam::accountid:role/S3F2DataAccessRole",
         "DeleteOldVersions": False,
+        "IgnoreObjectNotFoundExceptions": True,
     } == json.loads(response["body"])
 
 
@@ -104,6 +106,7 @@ def test_it_gets_data_mapper(validate_mapper, table):
         "Format": "parquet",
         "RoleArn": "arn:aws:iam::accountid:role/S3F2DataAccessRole",
         "DeleteOldVersions": False,
+        "IgnoreObjectNotFoundExceptions": True,
     }
     table.get_item.return_value = {"Item": mock_dm}
     get_response = handlers.get_data_mapper_handler(
@@ -152,6 +155,7 @@ def test_it_modifies_data_mapper(validate_mapper, table):
                 "Format": "parquet",
                 "RoleArn": "arn:aws:iam::accountid:role/S3F2DataAccessRole",
                 "DeleteOldVersions": False,
+                "IgnoreObjectNotFoundExceptions": True,
             }
         )
 
@@ -187,6 +191,7 @@ def test_it_modifies_data_mapper(validate_mapper, table):
         "CreatedBy": {"Username": "cognitoUsername", "Sub": "cognitoSub"},
         "RoleArn": "arn:aws:iam::accountid:role/S3F2DataAccessRole",
         "DeleteOldVersions": False,
+        "IgnoreObjectNotFoundExceptions": True,
     } == json.loads(edit_response["body"])
 
 
@@ -227,6 +232,7 @@ def test_it_supports_optionals(validate_mapper, table):
         },
         "Format": "parquet",
         "DeleteOldVersions": True,
+        "IgnoreObjectNotFoundExceptions": False,
         "RoleArn": "arn:aws:iam::accountid:role/S3F2DataAccessRole",
         "CreatedBy": {"Username": "cognitoUsername", "Sub": "cognitoSub"},
     } == json.loads(response["body"])

--- a/tests/unit/ecs_tasks/conftest.py
+++ b/tests/unit/ecs_tasks/conftest.py
@@ -13,6 +13,7 @@ def message_stub():
                 "Columns": [{"Column": "customer_id"}],
                 "CompositeColumns": [],
                 "DeleteOldVersions": False,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Format": "parquet",
                 "Manifest": "s3://temp-bucket/manifests/1234/dm54321/manifest.json",
                 **kwargs,

--- a/tests/unit/ecs_tasks/test_events.py
+++ b/tests/unit/ecs_tasks/test_events.py
@@ -9,6 +9,7 @@ from backend.ecs_tasks.delete_files.events import (
     sanitize_message,
     emit_deletion_event,
     emit_failure_event,
+    emit_skipped_event,
     get_emitter_id,
 )
 
@@ -26,6 +27,21 @@ def test_it_emits_deletions(mock_get_id, mock_emit, message_stub):
         "1234",
         "ObjectUpdated",
         {"Statistics": stats_stub, "Object": "s3://bucket/path/basic.parquet",},
+        "ECSTask_4567",
+    )
+
+
+@patch("backend.ecs_tasks.delete_files.events.emit_event")
+@patch("backend.ecs_tasks.delete_files.events.get_emitter_id")
+def test_it_emits_skips(mock_get_id, mock_emit, message_stub):
+    mock_get_id.return_value = "ECSTask_4567"
+    reason_stub = "Object not found"
+    msg = json.loads(message_stub())
+    emit_skipped_event(msg, reason_stub)
+    mock_emit.assert_called_with(
+        "1234",
+        "ObjectUpdateSkipped",
+        {"Reason": reason_stub, "Object": "s3://bucket/path/basic.parquet",},
         "ECSTask_4567",
     )
 

--- a/tests/unit/jobs/test_status_updater.py
+++ b/tests/unit/jobs/test_status_updater.py
@@ -46,7 +46,7 @@ def test_it_determines_job_has_errors_for_failed_queries(table):
 
 
 @patch("backend.lambdas.jobs.status_updater.table")
-def test_it_determines_job_has_errors_for_failed_object_updates(table):
+def test_it_determines_job_does_not_have_errors_for_failed_object_updates(table):
     table.get_item.return_value = {
         "Item": {"TotalObjectUpdateFailedCount": 0, "TotalQueryFailedCount": 0,}
     }

--- a/tests/unit/tasks/test_generate_queries.py
+++ b/tests/unit/tasks/test_generate_queries.py
@@ -56,6 +56,7 @@ def test_it_generates_queries_writes_manifests_populates_queue_and_returns_resul
             "Columns": [{"Column": "customer_id"}],
             "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
             "DeleteOldVersions": True,
+            "IgnoreObjectNotFoundExceptions": False,
             "Manifest": "s3://S3F2-manifests-bucket/manifests/test/a/manifest.json",
         }
     ]
@@ -160,6 +161,7 @@ class TestAthenaQueries:
                 "Columns": [{"Column": "customer_id", "Type": "Simple"}],
                 "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -229,6 +231,7 @@ class TestAthenaQueries:
                 "Columns": [{"Column": "customer_id", "Type": "Simple",}],
                 "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -311,6 +314,7 @@ class TestAthenaQueries:
                 "Columns": [{"Column": "customer_id", "Type": "Simple",}],
                 "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -390,6 +394,7 @@ class TestAthenaQueries:
                 "Columns": [{"Column": "customer_id", "Type": "Simple"}],
                 "PartitionKeys": [{"Key": "year", "Value": 2010}],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -458,6 +463,7 @@ class TestAthenaQueries:
                 ],
                 "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -546,6 +552,7 @@ class TestAthenaQueries:
                 ],
                 "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -678,6 +685,7 @@ class TestAthenaQueries:
                 ],
                 "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job1234567890/a/manifest.json",
             }
         ]
@@ -924,6 +932,7 @@ class TestAthenaQueries:
                     {"Key": "month", "Value": "01"},
                 ],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -997,6 +1006,7 @@ class TestAthenaQueries:
                         {"Key": "month", "Value": "12"},
                     ],
                     "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": False,
                     "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
                 },
                 {
@@ -1011,6 +1021,7 @@ class TestAthenaQueries:
                         {"Key": "month", "Value": "01"},
                     ],
                     "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": False,
                     "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
                 },
                 {
@@ -1025,6 +1036,7 @@ class TestAthenaQueries:
                         {"Key": "month", "Value": "02"},
                     ],
                     "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": False,
                     "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
                 },
             ],
@@ -1075,6 +1087,7 @@ class TestAthenaQueries:
                 },
                 "RoleArn": "arn:aws:iam::accountid:role/rolename",
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": True,
             },
             [
                 {
@@ -1102,6 +1115,7 @@ class TestAthenaQueries:
                     ],
                     "RoleArn": "arn:aws:iam::accountid:role/rolename",
                     "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": True,
                     "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
                 },
                 {
@@ -1117,6 +1131,7 @@ class TestAthenaQueries:
                     ],
                     "RoleArn": "arn:aws:iam::accountid:role/rolename",
                     "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": True,
                     "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
                 },
             ],
@@ -1192,6 +1207,7 @@ class TestAthenaQueries:
                 "Columns": [{"Column": "customer_id", "Type": "Simple"}],
                 "PartitionKeys": [{"Key": "product_category", "Value": "Books"}],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/B/manifest.json",
             }
         ]
@@ -1254,6 +1270,7 @@ class TestAthenaQueries:
                 "Columns": [{"Column": "customer_id", "Type": "Simple"}],
                 "PartitionKeys": [],
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -1318,6 +1335,7 @@ class TestAthenaQueries:
                 "PartitionKeys": [],
                 "RoleArn": "arn:aws:iam::accountid:role/rolename",
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
                 "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
             }
         ]
@@ -1579,6 +1597,7 @@ class TestAthenaQueries:
                     "Columns": [{"Column": "customer_id", "Type": "Simple"}],
                     "PartitionKeys": [{"Key": "year", "Value": "2018"}],
                     "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": False,
                     "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
                 },
                 {
@@ -1590,6 +1609,7 @@ class TestAthenaQueries:
                     "Columns": [{"Column": "customer_id", "Type": "Simple"}],
                     "PartitionKeys": [{"Key": "year", "Value": "2019"}],
                     "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": False,
                     "Manifest": "s3://S3F2-manifests-bucket/manifests/job_1234567890/a/manifest.json",
                 },
             ],

--- a/tests/unit/tasks/test_submit_query_results.py
+++ b/tests/unit/tasks/test_submit_query_results.py
@@ -57,12 +57,14 @@ def test_it_submits_results_to_be_batched(paginate_mock, batch_sqs_msgs_mock):
                 "Columns": columns,
                 "Object": "s3://mybucket/mykey1",
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
             },
             {
                 "JobId": "1234",
                 "Columns": columns,
                 "Object": "s3://mybucket/mykey2",
                 "DeleteOldVersions": True,
+                "IgnoreObjectNotFoundExceptions": False,
             },
         ],
     )
@@ -86,6 +88,7 @@ def test_it_propagates_optional_properties(paginate_mock, batch_sqs_msgs_mock):
             "JobId": "1234",
             "QueryId": "123",
             "Columns": columns,
+            "IgnoreObjectNotFoundExceptions": True,
         },
         SimpleNamespace(),
     )
@@ -98,6 +101,7 @@ def test_it_propagates_optional_properties(paginate_mock, batch_sqs_msgs_mock):
                 "Object": "s3://mybucket/mykey1",
                 "RoleArn": "arn:aws:iam:accountid:role/rolename",
                 "DeleteOldVersions": False,
+                "IgnoreObjectNotFoundExceptions": True,
             },
         ],
     )


### PR DESCRIPTION
*Description of changes:*
Currently a deletion job will fail if objects that were found in the Find phase no longer exist in the Delete phase. This can cause spurious failures when lifecycle policies are configured on a bucket which cause objects to expire.

This PR adds a data mapper parameter to allow users to ignore these errors. The default behavior remains the same.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
