### PR TITLE
Add table name to error msg when col is not found

### DIFF
--- a/backend/lambdas/tasks/generate_queries.py
+++ b/backend/lambdas/tasks/generate_queries.py
@@ -470,7 +470,7 @@ def get_column_info(col, table, is_partition):
 def cast_to_type(val, col, table, is_partition=False):
     col_type, can_be_identifier = get_column_info(col, table, is_partition)
     if not col_type:
-        raise ValueError("Column {} not found".format(col))
+        raise ValueError("Column {} not found at table {}".format(col,table))
     elif not can_be_identifier:
         raise ValueError(
             "Column {} is not a supported column type for querying".format(col)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:
If you have a big number of data mappers and column not found error is displayed, it's hard to determine which table the error happened. This PR adds the table information to the error message making straightforward the identification of the table.

*PR Checklist:*

- [ ] Changelog updated
- [ ] Unit tests (and integration tests if applicable) provided
- [ ] All tests pass
- [ ] Pre-commit checks pass
- [ ] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
