### PR TITLE
Improve performance for query generation task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.45 (unreleased)
 
+- [#303](https://github.com/awslabs/amazon-s3-find-and-forget/pull/303): Improve
+  performance of query generation step
 - [#301](https://github.com/awslabs/amazon-s3-find-and-forget/pull/301): Include
   table name to error when query generation fails due to an invalid column type
 - Dependency version updates for:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.45 (unreleased)
 
 - [#303](https://github.com/awslabs/amazon-s3-find-and-forget/pull/303): Improve
-  performance of query generation step
+  performance of Athena query generation
 - [#301](https://github.com/awslabs/amazon-s3-find-and-forget/pull/301): Include
   table name to error when query generation fails due to an invalid column type
 - Dependency version updates for:

--- a/tests/unit/tasks/test_generate_queries.py
+++ b/tests/unit/tasks/test_generate_queries.py
@@ -1421,13 +1421,9 @@ class TestAthenaQueries:
 
     @patch("backend.lambdas.tasks.generate_queries.glue_client")
     def test_it_returns_table(self, client):
-        client.get_table.return_value = {
-            "Table": {
-                "Name": "test",
-                "StorageDescriptor": {"Columns": [{"Name": "column", "Type": "int"}]},
-            }
-        }
+        client.get_table.return_value = {"Table": {"Name": "test"}}
         result = get_table("test_db", "test_table")
+        assert {"Name": "test"} == result
         client.get_table.assert_called_with(DatabaseName="test_db", Name="test_table")
 
     @patch("backend.lambdas.tasks.generate_queries.paginate")
@@ -1788,6 +1784,4 @@ def table_stub(
         "PartitionKeys": table_partition_keys,
         "TableType": "EXTERNAL_TABLE",
         "Parameters": {"EXTERNAL": "TRUE"},
-        "ColumnsTree": list(map(column_mapper, table_columns)),
-        "PartitionKeysTree": list(map(column_mapper, table_partition_keys)),
     }

--- a/tests/unit/tasks/test_generate_queries.py
+++ b/tests/unit/tasks/test_generate_queries.py
@@ -1745,13 +1745,6 @@ def partition_stub(values, columns, table_name="test_table"):
 def table_stub(
     columns, partition_keys, table_name="test_table", partition_keys_type="string"
 ):
-    table_columns = [
-        {"Name": col["Name"], "Type": col.get("Type", "string")} for col in columns
-    ]
-    table_partition_keys = [
-        {"Name": partition_key, "Type": partition_keys_type}
-        for partition_key in partition_keys
-    ]
     return {
         "Name": table_name,
         "DatabaseName": "test",
@@ -1761,7 +1754,10 @@ def table_stub(
         "LastAccessTime": 0.0,
         "Retention": 0,
         "StorageDescriptor": {
-            "Columns": table_columns,
+            "Columns": [
+                {"Name": col["Name"], "Type": col.get("Type", "string")}
+                for col in columns
+            ],
             "Location": "s3://bucket/location",
             "InputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
             "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
@@ -1781,7 +1777,10 @@ def table_stub(
             },
             "StoredAsSubDirectories": False,
         },
-        "PartitionKeys": table_partition_keys,
+        "PartitionKeys": [
+            {"Name": partition_key, "Type": partition_keys_type}
+            for partition_key in partition_keys
+        ],
         "TableType": "EXTERNAL_TABLE",
         "Parameters": {"EXTERNAL": "TRUE"},
     }


### PR DESCRIPTION
*Description of changes:*

When generating the queries, the current logic iterates over the data mappers and casts each match id by calling `cast_to_type`, which itself calls `get_column_info` to fetch info on the column to get the type, which itself always calls `column_mapper` to do stuff that is computationally heavy such as creating a tree that defines the schema, which is important for complex data types (types such as `struct`, `array`, `map`).

With this new change, the columns of each data mapper are converted to a tree calling `column_mapper` only once for each data mapper, so that `get_column_info` can lookup and traverse the tree without repeating the operation for each match id.

The result of this optimisation is important when processing hundreds or thousands of matches.
Before, `column_mapper` was called `len(data mappers)*len(deletion queue)`, now just `len(data mappers)`.

*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
