### PR TITLE
Fix cleanup bucket lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 
-## v0.49 (unreleased)
+## v0.49
 
-- [#314](https://github.com/awslabs/amazon-s3-find-and-forget/pull/314): Updated build_manifest_row to generate queries based on the deletion queue type
+- [#314](https://github.com/awslabs/amazon-s3-find-and-forget/pull/314): Fix
+  query generation step for Composite matches consisting of a single column
+- [#320](https://github.com/awslabs/amazon-s3-find-and-forget/pull/320): Fix
+  deployment issue introduced in v0.48
 
 ## v0.48
 

--- a/backend/lambdas/custom_resources/cleanup_bucket.py
+++ b/backend/lambdas/custom_resources/cleanup_bucket.py
@@ -26,7 +26,8 @@ def create(event, context):
 def update(event, context):
     props = event["ResourceProperties"]
     props_old = event["OldResourceProperties"]
-    if props_old["DeployWebUI"] == "true" and props["DeployWebUI"] == "false":
+    web_ui_deployed = props_old.get("DeployWebUI", "true")
+    if web_ui_deployed == "true" and props["DeployWebUI"] == "false":
         empty_bucket(props["Bucket"])
     return None
 

--- a/backend/lambdas/tasks/generate_queries.py
+++ b/backend/lambdas/tasks/generate_queries.py
@@ -85,7 +85,7 @@ def handler(event, context):
     }
 
 
-def build_manifest_row(columns, match_id, item_id, item_createdat,is_composite):
+def build_manifest_row(columns, match_id, item_id, item_createdat, is_composite):
     """
     Function for building each row of the manifest that will be written to S3.
 

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.48)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.49)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -168,7 +168,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.48'
+      Version: 'v0.49'
 
 Resources:
   TempBucket:

--- a/tests/unit/crs/test_cr_cleanup_bucket.py
+++ b/tests/unit/crs/test_cr_cleanup_bucket.py
@@ -66,6 +66,24 @@ def test_it_removes_all_objects_from_bucket_on_update_if_required(mock_empty_buc
 
 
 @patch("backend.lambdas.custom_resources.cleanup_bucket.empty_bucket")
+def test_it_removes_all_objects_from_bucket_on_update_if_required_before_v048(
+    mock_empty_bucket,
+):
+    event = {
+        "ResourceProperties": {"DeployWebUI": "false", "Bucket": "webuibucket"},
+        "OldResourceProperties": {
+            "Bucket": "webuibucket"
+        },  # DeployWebUI wasn't passed as param prior to 0.48
+    }
+
+    resp = update(event, MagicMock())
+
+    mock_empty_bucket.assert_called_with("webuibucket")
+
+    assert not resp
+
+
+@patch("backend.lambdas.custom_resources.cleanup_bucket.empty_bucket")
 def test_it_removes_all_objects_from_bucket_on_update_if_not_required(
     mock_empty_bucket,
 ):

--- a/tests/unit/tasks/test_generate_queries.py
+++ b/tests/unit/tasks/test_generate_queries.py
@@ -591,13 +591,11 @@ class TestAthenaQueries:
     @patch("backend.lambdas.tasks.generate_queries.get_table")
     @patch("backend.lambdas.tasks.generate_queries.get_partitions")
     def test_it_handles_single_composite_column(
-            self, get_partitions_mock, get_table_mock, bucket_mock
+        self, get_partitions_mock, get_table_mock, bucket_mock
     ):
         put_object_mock = MagicMock()
         bucket_mock.return_value = put_object_mock
-        columns = [
-            {"Name": "first_name"}
-        ]
+        columns = [{"Name": "first_name"}]
         partition_keys = ["product_category"]
         partitions = [["Books"]]
         get_table_mock.return_value = table_stub(columns, partition_keys)
@@ -618,9 +616,7 @@ class TestAthenaQueries:
             },
             [
                 {
-                    "MatchId": [
-                        {"Column": "first_name", "Value": "John"}
-                    ],
+                    "MatchId": [{"Column": "first_name", "Value": "John"}],
                     "Type": "Composite",
                     "DataMappers": ["a"],
                     "CreatedAt": 1614698440,
@@ -652,17 +648,17 @@ class TestAthenaQueries:
         put_object_mock.put_object.assert_called_with(
             Key="manifests/job_1234567890/a/manifest.json",
             Body=(
-                    json.dumps(
-                        {
-                            "Columns": ["first_name"],
-                            "MatchId": ["John"],
-                            "DeletionQueueItemId": "id1234",
-                            "CreatedAt": 1614698440,
-                            "QueryableColumns": "first_name",
-                            "QueryableMatchId": "John",
-                        }
-                    )
-                    + "\n"
+                json.dumps(
+                    {
+                        "Columns": ["first_name"],
+                        "MatchId": ["John"],
+                        "DeletionQueueItemId": "id1234",
+                        "CreatedAt": 1614698440,
+                        "QueryableColumns": "first_name",
+                        "QueryableMatchId": "John",
+                    }
+                )
+                + "\n"
             ),
         )
 


### PR DESCRIPTION
*Issue #, if available:*
Closes: #319 

*Description of changes:*
Have a default value for the setting, so that upgrading from versions prior to 0.48 succeeds.

Note 1: we are using the same mechanism to fetch variables in 2 other custom resources, but because they are new with 0.48, they are executed on create so this shouldn't happen there.

Note 2: after rebasing doing to the merge of #314 I thought I would update the changelog to make it a bit clearer and I made it part of this PR, as well as some re-formatting due to #314 probably not running the pre-commit format, but it should be nothing big.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
