### PR TITLE
Submit Query Lambda Performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.53 (unreleased)
+
+- [#327](https://github.com/awslabs/amazon-s3-find-and-forget/pull/327): Improve
+  performance of Athena results handler
+
 ## v0.52
 
 - [#318](https://github.com/awslabs/amazon-s3-find-and-forget/pull/318): Added

--- a/backend/ecs_tasks/delete_files/utils.py
+++ b/backend/ecs_tasks/delete_files/utils.py
@@ -3,7 +3,7 @@ from botocore.exceptions import ClientError
 
 
 def remove_none(d: dict):
-    return {k: v for k, v in d.items() if v is not None and v is not ""}
+    return {k: v for k, v in d.items() if v is not None and v != ""}
 
 
 def retry_wrapper(fn, retry_wait_seconds=2, retry_factor=2, max_retries=5):

--- a/tests/unit/tasks/test_submit_query_results.py
+++ b/tests/unit/tasks/test_submit_query_results.py
@@ -2,36 +2,24 @@ import os
 from types import SimpleNamespace
 
 import pytest
-from mock import patch, ANY
+from mock import call, patch, ANY
 
 with patch.dict(os.environ, {"QueueUrl": "test"}):
     from backend.lambdas.tasks.submit_query_results import handler
 
 pytestmark = [pytest.mark.unit, pytest.mark.task]
 
+test_data = [
+    {"Data": [{"VarCharValue": "$path"}]},
+    {"Data": [{"VarCharValue": "s3://mybucket/mykey1"}]},
+    {"Data": [{"VarCharValue": "s3://mybucket/mykey2"}]},
+]
+
 
 @patch("backend.lambdas.tasks.submit_query_results.batch_sqs_msgs")
 @patch("backend.lambdas.tasks.submit_query_results.paginate")
 def test_it_returns_only_paths(paginate_mock, batch_sqs_msgs_mock):
-    paginate_mock.return_value = iter(
-        [
-            {
-                "Data": [
-                    {"VarCharValue": "$path"},
-                ]
-            },
-            {
-                "Data": [
-                    {"VarCharValue": "s3://mybucket/mykey1"},
-                ]
-            },
-            {
-                "Data": [
-                    {"VarCharValue": "s3://mybucket/mykey2"},
-                ]
-            },
-        ]
-    )
+    paginate_mock.return_value = iter(test_data)
     columns = [{"Column": "customer_id", "MatchIds": ["2732559"]}]
 
     resp = handler(
@@ -49,25 +37,7 @@ def test_it_returns_only_paths(paginate_mock, batch_sqs_msgs_mock):
 @patch("backend.lambdas.tasks.submit_query_results.batch_sqs_msgs")
 @patch("backend.lambdas.tasks.submit_query_results.paginate")
 def test_it_submits_results_to_be_batched(paginate_mock, batch_sqs_msgs_mock):
-    paginate_mock.return_value = iter(
-        [
-            {
-                "Data": [
-                    {"VarCharValue": "$path"},
-                ]
-            },
-            {
-                "Data": [
-                    {"VarCharValue": "s3://mybucket/mykey1"},
-                ]
-            },
-            {
-                "Data": [
-                    {"VarCharValue": "s3://mybucket/mykey2"},
-                ]
-            },
-        ]
-    )
+    paginate_mock.return_value = iter(test_data)
     columns = [{"Column": "customer_id", "MatchIds": ["2732559"]}]
 
     handler(
@@ -101,21 +71,63 @@ def test_it_submits_results_to_be_batched(paginate_mock, batch_sqs_msgs_mock):
 
 @patch("backend.lambdas.tasks.submit_query_results.batch_sqs_msgs")
 @patch("backend.lambdas.tasks.submit_query_results.paginate")
-def test_it_propagates_optional_properties(paginate_mock, batch_sqs_msgs_mock):
+@patch("backend.lambdas.tasks.submit_query_results.MSG_BATCH_SIZE", 2)
+def test_it_submits_results_to_be_batched_multiple_times_according_to_batch_size(
+    paginate_mock, batch_sqs_msgs_mock
+):
     paginate_mock.return_value = iter(
-        [
-            {
-                "Data": [
-                    {"VarCharValue": "$path"},
-                ]
-            },
-            {
-                "Data": [
-                    {"VarCharValue": "s3://mybucket/mykey1"},
-                ]
-            },
-        ]
+        [*test_data, {"Data": [{"VarCharValue": "s3://mybucket/mykey3"}]}]
     )
+    columns = [{"Column": "customer_id", "MatchIds": ["2732559"]}]
+
+    handler(
+        {
+            "JobId": "1234",
+            "QueryId": "123",
+            "Columns": columns,
+        },
+        SimpleNamespace(),
+    )
+
+    assert batch_sqs_msgs_mock.call_args_list == [
+        call(
+            ANY,
+            [
+                {
+                    "JobId": "1234",
+                    "Columns": columns,
+                    "Object": "s3://mybucket/mykey1",
+                    "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": False,
+                },
+                {
+                    "JobId": "1234",
+                    "Columns": columns,
+                    "Object": "s3://mybucket/mykey2",
+                    "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": False,
+                },
+            ],
+        ),
+        call(
+            ANY,
+            [
+                {
+                    "JobId": "1234",
+                    "Columns": columns,
+                    "Object": "s3://mybucket/mykey3",
+                    "DeleteOldVersions": True,
+                    "IgnoreObjectNotFoundExceptions": False,
+                }
+            ],
+        ),
+    ]
+
+
+@patch("backend.lambdas.tasks.submit_query_results.batch_sqs_msgs")
+@patch("backend.lambdas.tasks.submit_query_results.paginate")
+def test_it_propagates_optional_properties(paginate_mock, batch_sqs_msgs_mock):
+    paginate_mock.return_value = iter(test_data)
     columns = [{"Column": "customer_id", "MatchIds": ["2732559"]}]
 
     handler(
@@ -136,6 +148,14 @@ def test_it_propagates_optional_properties(paginate_mock, batch_sqs_msgs_mock):
                 "JobId": "1234",
                 "Columns": columns,
                 "Object": "s3://mybucket/mykey1",
+                "RoleArn": "arn:aws:iam:accountid:role/rolename",
+                "DeleteOldVersions": False,
+                "IgnoreObjectNotFoundExceptions": True,
+            },
+            {
+                "JobId": "1234",
+                "Columns": columns,
+                "Object": "s3://mybucket/mykey2",
                 "RoleArn": "arn:aws:iam:accountid:role/rolename",
                 "DeleteOldVersions": False,
                 "IgnoreObjectNotFoundExceptions": True,


### PR DESCRIPTION
*Description of changes:*

Improve memory management for the Submit Query Lambda. The current work should be useful when receiving hundreds of thousands of results for a single query. Rather than reading the whole set of results and storing in memory, with this code changes we read in batches using the generator that makes paginated calls to API, and then we save results to SQS earlier and in batches in order to use less memory.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
