### PR TITLE
Force spawn for multiprocessing and consistent PID logging on ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Change Log
 
-## v0.55 (unreleased)
+## v0.55
 
+- [#342](https://github.com/awslabs/amazon-s3-find-and-forget/pull/342): Fix for
+  an issue affecting jobs terminating with FORGET_PARTIALLY_FAILED despite
+  correctly processing all the objects, caused by ECS running multi-processing
+  in fork mode. It includes improvement on multi-processing handling, as well as
+  enhanced logging to include PIDs when running on ECS during the Forget phase
 - [#341](https://github.com/awslabs/amazon-s3-find-and-forget/pull/341): Upgrade
   build dependencies
 - [#340](https://github.com/awslabs/amazon-s3-find-and-forget/pull/340): Upgrade

--- a/backend/ecs_tasks/delete_files/events.py
+++ b/backend/ecs_tasks/delete_files/events.py
@@ -1,6 +1,7 @@
 import json
 import os
 import logging
+import sys
 import urllib.request
 import urllib.error
 from collections.abc import Iterable
@@ -9,6 +10,11 @@ from functools import lru_cache
 from boto_utils import emit_event
 
 logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("LOG_LEVEL", logging.INFO))
+formatter = logging.Formatter("[%(levelname)s] PID:%(process)d> %(message)s")
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 
 def emit_deletion_event(message_body, stats):

--- a/backend/ecs_tasks/delete_files/main.py
+++ b/backend/ecs_tasks/delete_files/main.py
@@ -5,7 +5,7 @@ import sys
 import signal
 import time
 import logging
-from multiprocessing import Pool, cpu_count
+from multiprocessing import cpu_count, get_context
 from operator import itemgetter
 
 import boto3
@@ -40,7 +40,7 @@ ROLE_SESSION_NAME = "s3f2"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("LOG_LEVEL", logging.INFO))
-formatter = logging.Formatter("[%(levelname)s] %(message)s")
+formatter = logging.Formatter("[%(levelname)s] PID:%(process)d> %(message)s")
 handler = logging.StreamHandler(stream=sys.stdout)
 handler.setFormatter(formatter)
 logger.addHandler(handler)
@@ -280,7 +280,7 @@ def main(queue_url, max_messages, wait_time, sleep_time):
     logger.info("CPU count for system: %s", cpu_count())
     messages = []
     queue = get_queue(queue_url)
-    with Pool(maxtasksperchild=1) as pool:
+    with get_context("spawn").Pool(maxtasksperchild=1) as pool:
         signal.signal(signal.SIGINT, lambda *_: kill_handler(messages, pool))
         signal.signal(signal.SIGTERM, lambda *_: kill_handler(messages, pool))
         while 1:

--- a/backend/ecs_tasks/delete_files/parquet_handler.py
+++ b/backend/ecs_tasks/delete_files/parquet_handler.py
@@ -11,7 +11,7 @@ import pyarrow.parquet as pq
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("LOG_LEVEL", logging.INFO))
-formatter = logging.Formatter("[%(levelname)s] %(message)s")
+formatter = logging.Formatter("[%(levelname)s] PID:%(process)d> %(message)s")
 handler = logging.StreamHandler(stream=sys.stdout)
 handler.setFormatter(formatter)
 logger.addHandler(handler)

--- a/backend/ecs_tasks/delete_files/s3.py
+++ b/backend/ecs_tasks/delete_files/s3.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import sys
 from functools import lru_cache
 from urllib.parse import urlencode, quote_plus
 from tenacity import (
@@ -49,6 +51,11 @@ s3transfer.upload.CompleteMultipartUploadTask = CompleteMultipartUploadTask
 
 
 logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("LOG_LEVEL", logging.INFO))
+formatter = logging.Formatter("[%(levelname)s] PID:%(process)d> %(message)s")
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 
 def save(client, buf, bucket, key, metadata, source_version=None):

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.54)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.55)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -194,7 +194,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.54'
+      Version: 'v0.55'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
*Description of changes:*

This changes follow a troubleshooting for an issue observed with `v0.53` running on Python `3.9.15` where there is a false negative on a Job execution (termination with a partially failed result for an object that was successfully processed).
According to logs, the kill handler (to be executed from the parent process in the ECS task) seems to be intercepted by the children processes during multi-processing. One of the children is working with an old copy of the data, that includes the old message, and fails when cleaning up the message from SQS as it's been deleted already.

```
2022-11-02T10:42:45.602-07:00	[INFO] Fetching messages...
2022-11-02T10:42:45.624-07:00	[INFO] Message received
2022-11-02T10:42:52.291-07:00	[INFO] Downloading and opening s3://<redacted>/<redacted-s3-object-1> object in-memory
2022-11-02T10:42:52.328-07:00	[INFO] Using object version <redacted-old-version> as source
2022-11-02T10:42:52.382-07:00	[INFO] Generating new file without matches
2022-11-02T10:42:52.435-07:00	[INFO] Row group 1/1
2022-11-02T10:42:52.968-07:00	[INFO] Uploading new object version to S3
2022-11-02T10:42:53.125-07:00	[INFO] New object version: <redacted-new-version>
2022-11-02T10:42:53.153-07:00	[INFO] Deleting object <redacted-s3-object-1> versions older than version <redacted-new-version>
2022-11-02T10:42:53.342-07:00	[INFO] Fetching messages...
2022-11-02T10:42:58.374-07:00	[INFO] No messages. Sleeping
2022-11-02T10:43:28.375-07:00	[INFO] Fetching messages...
2022-11-02T10:43:33.415-07:00	[INFO] No messages. Sleeping
2022-11-02T10:43:49.440-07:00	[INFO] Received shutdown signal. Cleaning up 0 messages
2022-11-02T10:43:49.441-07:00	[INFO] Received shutdown signal. Cleaning up 1 messages
2022-11-02T10:43:49.441-07:00	[INFO] Received shutdown signal. Cleaning up 0 messages
2022-11-02T10:43:49.441-07:00	[ERROR] SIGINT/SIGTERM received during processing
2022-11-02T10:43:49.765-07:00	[ERROR] Unable to gracefully cleanup message: An error occurred (InvalidParameterValue) when calling the ChangeMessageVisibility operation: Value <redacted> for parameter ReceiptHandle is invalid. Reason: Message does not exist or is not available for visibility timeout change.
```

By looking at the logs, we can see a successful `ObjectUpdated` log:
```
{
    "EventData": {
        "Statistics": { "ProcessedRows": 427, "DeletedRows": 1 },
        "Object": "s3://<redacted>/<redacted-s3-object-1>"
    },
    "Expires": 1670002462,
    "EmitterId": "ECSTask_<redacted>",
    "Sk": "<redacted>",
    "Id": "<redacted>",
    "EventName": "ObjectUpdated",
    "Type": "JobEvent",
    "CreatedAt": 1667410973
}
```

But we then see an `ObjectUpdateFailed` for the same object, for the failed cleanup we mentioned previously.

```
{
    "EventData": {
    "Message": {
        "DeleteOldVersions": true,
        "Format": "parquet",
        "Columns": [{ "Column": "entity", "Type": "Simple" }],
        "IgnoreObjectNotFoundExceptions": true,
        "Object": "s3://<redacted>/<redacted-s3-object-1>",
        "Manifest": "s3://<redacted>/manifests/<redacted-job-id>/<redacted>/manifest.json",
        "JobId": "<redacted-job-id>",
        "RoleArn": "arn:aws:iam::<redacted>:role/S3F2DataAccessRole"
    },
    "Error": "SIGINT/SIGTERM received during processing"
    },
    "Expires": 1670002462,
    "EmitterId": "ECSTask_<redacted-ecs-task>",
    "Sk": "<redacted>",
    "Id": "<redacted-job-id>",
    "EventName": "ObjectUpdateFailed",
    "Type": "JobEvent",
    "CreatedAt": 1667411029
}
```

An explanation of this behaviour may be running the multi-processing in `fork` mode, that appears to be the default for UNIX (but not in MacOS - that didn't facilitate debugging). It is possible to override the mode globally, which I assume may be done currently or in the past versions by some dependencies depending on their version, version of python, and behaviour.

More on python multi-processing: [Python official docs on contexts](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) and an [article that dives into fork vs spawn](https://pythonspeed.com/articles/python-multiprocessing/).

In summary, after troubleshooting this issue, I was able to force our multi-processing to `fork` to reproduce locally the exact issue here. By forking the parent process, the children were listening for kill events based on a old version of `messages` in [here](https://github.com/awslabs/amazon-s3-find-and-forget/blob/master/backend/ecs_tasks/delete_files/main.py#L284) and that was incorrect and causing the same issue. By forcing to `spawn` instead, I went to the desired behaviour.

This PR therefore forces multiprocessing to use `spawn` to prevent conflicts with other global settings, and also introduces PID to the logs, so that we can facilitate troubleshooting of similar issues in the future.
Example:
```
[INFO] PID:1> CPU count for system: 4
[INFO] PID:1> Fetching messages...
[INFO] PID:13> Message received
[INFO] PID:13> Downloading and opening s3://<redacted>/test/2019/08/20/test.parquet object in-memory
[INFO] PID:13> Using object version <redacted> as source
[INFO] PID:13> Generating new file without matches
[INFO] PID:13> Row group 1/1
[INFO] PID:13> Uploading new object version to S3
[INFO] PID:13> Object settings: {'CacheControl': 'cache', 'ContentType': 'binary/octet-stream', 'Metadata': {'foo': 'bar'}, 'GrantFullControl': 'id=<redacted>'}
[INFO] PID:13> Saving updated object to s3://<redacted>/test/2019/08/20/test.parquet
[INFO] PID:13> Object uploaded to S3
[INFO] PID:13> Processing of file s3://<redacted>/test/2019/08/20/test.parquet complete
[INFO] PID:13> New object version: <redacted>
[INFO] PID:1> Fetching messages...
[INFO] PID:1> No messages. Sleeping
[INFO] PID:1> Fetching messages...
[INFO] PID:1> No messages. Sleeping
[INFO] PID:1> Received shutdown signal. Cleaning up 0 messages
```

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
