### PR TITLE
Better error handling when handling invalid match ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.56 (unreleased)
+
+- [#343](https://github.com/awslabs/amazon-s3-find-and-forget/pull/343): Upgrade
+  frontend dependencies
+- [#345](https://github.com/awslabs/amazon-s3-find-and-forget/pull/345):
+  Improved error handling when processing invalid match IDs during the Query
+  Planning phase
+
 ## v0.55
 
 - [#342](https://github.com/awslabs/amazon-s3-find-and-forget/pull/342): Fix for


### PR DESCRIPTION
*Issue #, if available:*
Closes: #250 

*Description of changes:*
When a match ID is added but it's invalid (for instance, a string in place of an integer that fails to cast to a number), an error is shown not providing data mappers information (needed when having lots of data mappers and adding a match to ALL datamappers). In addition, its value is shown in the logs and it should be masked (with this change, I decided to show the DeletionQueueItemId, which is a auto-generated ID for identifying the item in Dynamo, that you need when you use the Queue API to delete the match).

Note that this could possibly be avoided by adding validation on the Data Mapper level - which currently doesn't do any during Match Id creation. (But that may not be trivial as Match Id API operation is synchronous and if you batch insert with hundreds of data mappers, that's lots to do). Even in case we add that in the future, I think the changes in this PR are still worth having for better handling and making sure the match id value is not shown in the logs.

Before:
```
{
  "EventData": {
    "Error": "ValueError",
    "EventName": "FindPhaseFailed",
    "State": {
      "ExecutionName": "[redacted]",
      "DeletionTasksMaxNumber": 3,
      "QueryQueueWaitSeconds": 3,
      "AthenaConcurrencyLimit": 20,
      "ForgetQueueWaitSeconds": 30,
      "ErrorDetails": {
        "Error": "ValueError",
        "Cause": "{\"errorMessage\": \"invalid literal for int() with base 10: 'foo'\", \"errorType\": \"ValueError\", \"stackTrace\": [\"  File \\\"/opt/python/decorators.py\\\", line 34, in wrapper\\n    return handler(event, *args, **kwargs)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 61, in handler\\n    queries = generate_athena_queries(data_mapper, deletion_items, job_id)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 177, in generate_athena_queries\\n    casted = cast_to_type(mid, column, table)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 473, in cast_to_type\\n    return int(val)\\n\"]}"
      },
      "QueryExecutionWaitSeconds": 3,
      "ExecutionId": "arn:aws:states:[redacted]:[redacted]:execution:S3F2-StateMachine:[redacted]"
    },
    "Cause": "{\"errorMessage\": \"invalid literal for int() with base 10: 'foo'\", \"errorType\": \"ValueError\", \"stackTrace\": [\"  File \\\"/opt/python/decorators.py\\\", line 34, in wrapper\\n    return handler(event, *args, **kwargs)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 61, in handler\\n    queries = generate_athena_queries(data_mapper, deletion_items, job_id)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 177, in generate_athena_queries\\n    casted = cast_to_type(mid, column, table)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 473, in cast_to_type\\n    return int(val)\\n\"]}"
  },
  "EmitterId": "StepFunctions",
  "Sk": "[redacted]",
  "Id": "[redacted]",
  "EventName": "FindPhaseFailed",
  "Type": "JobEvent",
  "CreatedAt": 1620794859
}
```

After:
```
{
  "EventData": {
    "Error": "ValueError",
    "EventName": "FindPhaseFailed",
    "State": {
      "ExecutionName": "<redacted>",
      "AthenaQueryMaxRetries": 0,
      "DeletionTasksMaxNumber": 1,
      "QueryQueueWaitSeconds": 1,
      "AthenaConcurrencyLimit": 15,
      "ForgetQueueWaitSeconds": 5,
      "ErrorDetails": {
        "Error": "ValueError",
        "Cause": "{\"errorMessage\": \"Invalid match ID (DeletionQueueItemId: 'id123') on Data Mapper 'test'. Casting failed: expected type for column 'customerid': 'int'\", \"errorType\": \"ValueError\", \"requestId\": \"<redacted>\", \"stackTrace\": [\"  File \\\"/opt/python/decorators.py\\\", line 34, in wrapper\\n    return handler(event, *args, **kwargs)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 62, in handler\\n    queries = generate_athena_queries(data_mapper, deletion_items, job_id)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 220, in generate_athena_queries\\n    raise ValueError(err_message)\\n\"]}"
      },
      "QueryExecutionWaitSeconds": 1,
      "ExecutionId": "arn:aws:states:<redacted>:<redacted>:execution:S3F2-StateMachine:<redacted>"
    },
    "Cause": "{\"errorMessage\": \"Invalid match ID (DeletionQueueItemId: 'id123') on Data Mapper 'test'. Casting failed: expected type for column 'customerid': 'int'\", \"errorType\": \"ValueError\", \"requestId\": \"<redacted>\", \"stackTrace\": [\"  File \\\"/opt/python/decorators.py\\\", line 34, in wrapper\\n    return handler(event, *args, **kwargs)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 62, in handler\\n    queries = generate_athena_queries(data_mapper, deletion_items, job_id)\\n\", \"  File \\\"/var/task/generate_queries.py\\\", line 220, in generate_athena_queries\\n    raise ValueError(err_message)\\n\"]}"
  },
  "EmitterId": "StepFunctions",
  "Sk": "<redacted>#<redacted>",
  "Id": "<redacted>",
  "EventName": "FindPhaseFailed",
  "Type": "JobEvent",
  "CreatedAt": 1670591517
}
```

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
