### PR TITLE
Remove redundant put call to DDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.57 (unreleased)
+
+- [#348](https://github.com/awslabs/amazon-s3-find-and-forget/pull/348): Cost
+  and performance improvement for Queue API
+
 ## v0.56
 
 - [#343](https://github.com/awslabs/amazon-s3-find-and-forget/pull/343): Upgrade

--- a/backend/lambdas/queue/handlers.py
+++ b/backend/lambdas/queue/handlers.py
@@ -48,7 +48,6 @@ def enqueue_handler(event, context):
     validate_queue_items([body])
     user_info = get_user_info(event)
     item = enqueue_items([body], user_info)[0]
-    deletion_queue_table.put_item(Item=item)
     return {"statusCode": 201, "body": json.dumps(item, cls=DecimalEncoder)}
 
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -50,18 +50,17 @@ a fatal error from which the system cannot recover.
 ### Job appears stuck in FORGET_COMPLETED_CLEANUP_IN_PROGRESS
 
 If you are running a job with a very large queue of matches (more than 100K
-entries), the Lambda function that removes the processed matches from the queue after a
-successful job may need to use a large amount of memory to process the deletions
-efficiently within the 15 minutes timeout. If you notice that the job status
-doesn't update after an hour, the queue size doesn't decrease, and a spike in
-memory usage for the Stream Processor Lambda function, it is likely that the system is
-stuck and you won't be able to run any other job.
+entries), the Lambda function that removes the processed matches from the queue
+after a successful job may need to use a large amount of memory to process the
+deletions efficiently within the 15 minutes timeout. If you notice that the job
+status doesn't update after an hour, the queue size doesn't decrease, and a
+spike in memory usage for the Stream Processor Lambda function, it is likely
+that the system is stuck and you won't be able to run any other job.
 
 To troubleshoot this scenario:
 
-1. Edit the DynamoDB item for the given JobID and change
-   the Status to `COMPLETED_CLEANUP_FAILED` in order to be able to start a new
-   job.
+1. Edit the DynamoDB item for the given JobID and change the Status to
+   `COMPLETED_CLEANUP_FAILED` in order to be able to start a new job.
    - Using the DynamoDB AWS Console, choose the JobTable (the name will be
      something like
      `<stackName>-DDBStack-XXXXXXXXXXXXX-JobTableXXXXXX-XXXXXXXXXXXX`) and
@@ -74,8 +73,9 @@ To troubleshoot this scenario:
      `COMPLETED_CLEANUP_FAILED`.
    - Choose `Save changes`.
 2. Update the solution CloudFormation stack and specify a larger
-   `LambdaJobsMemorySize` parameter value. See the 
-   [AWS Lambda Operator Guide](https://docs.aws.amazon.com/lambda/latest/operatorguide/computing-power.html) for valid values.
+   `LambdaJobsMemorySize` parameter value. See the
+   [AWS Lambda Operator Guide](https://docs.aws.amazon.com/lambda/latest/operatorguide/computing-power.html)
+   for valid values.
 3. Run a new Job and monitor the Stream Processor Lambda memory usage during the
    next jobs.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -216,10 +216,10 @@ resources.
      see [Fargate Configuration]
    - **DeletionTaskMemory:** (Default: 30720) Fargate task memory limit. For
      more info see [Fargate Configuration]
-   - **LambdaAPIMemorySize:** (Default: 128) The memory allocated to API
-     handler Lambda functions. For more info see [Lambda Configuration]
-   - **LambdaJobsMemorySize:** (Default: 512) The memory allocated to
-     Deletion Job Lambda functions. For more info see [Lambda Configuration]
+   - **LambdaAPIMemorySize:** (Default: 128) The memory allocated to API handler
+     Lambda functions. For more info see [Lambda Configuration]
+   - **LambdaJobsMemorySize:** (Default: 512) The memory allocated to Deletion
+     Job Lambda functions. For more info see [Lambda Configuration]
    - **QueryExecutionWaitSeconds:** (Default: 3) How long to wait when checking
      if an Athena Query has completed.
    - **QueryQueueWaitSeconds:** (Default: 3) How long to wait when checking if


### PR DESCRIPTION
There is a duplicated call to put_item in DDB that has no effect in functionality (put for same ID) but potentially duplicates cost and performance for adding items to the queue. This PR is to remove this redundant call.

It is caused by a mistake when doing the refactoring in https://github.com/awslabs/amazon-s3-find-and-forget/pull/200

*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
