### PR TITLE
Explicitly turn off use of S3 ACLs for Web UI Bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.59 (unreleased)
+
+- [#360](https://github.com/awslabs/amazon-s3-find-and-forget/pull/360):
+  Refactor of Web UI S3 bucket access control mechanisms
+
 ## v0.58
 
 - [#359](https://github.com/awslabs/amazon-s3-find-and-forget/pull/359): Fix UI

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ redeploy-containers:
 redeploy-frontend:
 	$(eval WEBUI_BUCKET := $(shell aws cloudformation describe-stacks --stack-name S3F2 --query 'Stacks[0].Outputs[?OutputKey==`WebUIBucket`].OutputValue' --output text))
 	make build-frontend
-	cd frontend/build && aws s3 cp --recursive . s3://$(WEBUI_BUCKET) --acl public-read --exclude *settings.js
+	cd frontend/build && aws s3 cp --recursive . s3://$(WEBUI_BUCKET) --exclude *settings.js
 
 run-local-container:
 	make pre-run

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -187,16 +187,11 @@ Resources:
             pre_build:
               commands:
                 - BUCKET="${WEB_UI_BUCKET}"
-                - ACL="private"
-                - |
-                  if [ "${CLOUDFRONT_DISTRIBUTION}" = "none" ]; then
-                    ACL="public-read"
-                  fi
                 - echo "${WEB_SETTINGS}" > frontend/build/settings.js
             build:
               commands:
                 - cd frontend/build
-                - aws s3 cp . s3://$BUCKET --acl $ACL --recursive
+                - aws s3 cp . s3://$BUCKET --recursive
             post_build:
               commands:
                 - |

--- a/templates/web_ui.yaml
+++ b/templates/web_ui.yaml
@@ -24,6 +24,20 @@ Resources:
   WebUIBucket:
     Type: AWS::S3::Bucket
     Properties:
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        IgnorePublicAcls: True
+        BlockPublicPolicy: !If
+          - WithCloudFront
+          - True
+          - False
+        RestrictPublicBuckets: !If
+          - WithCloudFront
+          - True
+          - False
       VersioningConfiguration:
         Status: Enabled
       BucketEncryption: 
@@ -68,7 +82,11 @@ Resources:
               Resource: !Sub arn:${AWS::Partition}:s3:::${WebUIBucket}/*
               Principal:
                 CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
-            - !Ref AWS::NoValue
+            - Sid: AllowDirectAccess
+              Action: s3:GetObject
+              Effect: Allow
+              Resource: !Sub arn:${AWS::Partition}:s3:::${WebUIBucket}/*
+              Principal: "*"
 
   CloudFrontOriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

This is needed due to default behaviour changes in S3[1]. Following the changes, new S3 buckets will default to having ACLs disabled. When ACLs are disabled, PUT operations specifying an ACL are rejected. This will result in the Web UI failing to upload to the S3 bucket in new deployments.

There are two options to solve this: explicitly enable ACLs, or to stop using ACLs. I have chosen the latter. This means that access to the Web UI bucket is now controlled by the bucket policy alone.

I have manually tested for both `CreateCloudFrontDistribution` parameter values.

References:
1. https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

*PR Checklist:*

- [x] Changelog updated
- [ ] Unit tests (and integration tests if applicable) provided
- [ ] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
