### PR TITLE
Update CloudFront to use OAC instead of OAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.59 (unreleased)
 
+- [#363](https://github.com/awslabs/amazon-s3-find-and-forget/pull/363): Bump
+  cfn-lint version, update CloudFront to use OAC instead of OAI
 - [#360](https://github.com/awslabs/amazon-s3-find-and-forget/pull/360):
   Refactor of Web UI S3 bucket access control mechanisms
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ generate-pip-requirements: $(patsubst %.in,%.txt,$(shell find . -type f -name re
 
 .PHONY: lint-cfn
 lint-cfn:
-	$(VENV)/bin/cfn-lint templates/*
+	$(VENV)/bin/cfn-lint -i W3002 templates/*
 
 package:
 	make package-artefacts

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 pip-tools>=6.12.1
 pytest==7.2.0
 certifi>=2022.12.7
-cfn-lint==0.61.0
+cfn-lint==0.77.3
 cfn-flip==1.3.0
 mock==4.0.1
 pytest-cov==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ aws-assume-role-lib==2.10.0
     # via
     #   -r ./backend/ecs_tasks/delete_files/requirements.txt
     #   -r ./backend/lambda_layers/aws_sdk/requirements.txt
-aws-sam-translator==1.48.0
+aws-sam-translator==1.66.0
     # via cfn-lint
 black==22.3.0
     # via -r requirements.in
@@ -47,7 +47,7 @@ cfgv==3.3.1
     # via pre-commit
 cfn-flip==1.3.0
     # via -r requirements.in
-cfn-lint==0.61.0
+cfn-lint==0.77.3
     # via -r requirements.in
 charset-normalizer==2.1.0
     # via requests
@@ -97,6 +97,8 @@ junit-xml==1.9
     # via cfn-lint
 mock==4.0.1
     # via -r requirements.in
+mpmath==1.3.0
+    # via sympy
 mypy-extensions==0.4.3
     # via black
 networkx==2.8.5
@@ -138,6 +140,8 @@ pycparser==2.21
     # via
     #   -r ./backend/ecs_tasks/delete_files/requirements.txt
     #   cffi
+pydantic==1.10.7
+    # via aws-sam-translator
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.18.1
@@ -169,6 +173,8 @@ pyyaml==6.0
     #   cfn-lint
     #   pre-commit
     #   yq
+regex==2023.3.23
+    # via cfn-lint
 requests==2.28.1
     # via -r requirements.in
 s3transfer==0.6.0
@@ -187,6 +193,8 @@ six==1.16.0
     #   jsonschema
     #   junit-xml
     #   python-dateutil
+sympy==1.11.1
+    # via cfn-lint
 tenacity==8.0.1
     # via -r ./backend/ecs_tasks/delete_files/requirements.txt
 toml==0.10.2
@@ -198,9 +206,13 @@ tomli==2.0.1
     #   black
     #   build
     #   coverage
+    #   pep517
     #   pytest
-typing-extensions==4.3.0
-    # via black
+typing-extensions==4.5.0
+    # via
+    #   aws-sam-translator
+    #   black
+    #   pydantic
 urllib3==1.26.11
     # via
     #   -r ./backend/ecs_tasks/delete_files/requirements.txt

--- a/templates/web_ui.yaml
+++ b/templates/web_ui.yaml
@@ -81,19 +81,26 @@ Resources:
               Effect: Allow
               Resource: !Sub arn:${AWS::Partition}:s3:::${WebUIBucket}/*
               Principal:
-                CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+                Service: cloudfront.amazonaws.com
+              Condition:
+                StringEquals:
+                  "AWS:SourceArn": !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution.Id}"
             - Sid: AllowDirectAccess
               Action: s3:GetObject
               Effect: Allow
               Resource: !Sub arn:${AWS::Partition}:s3:::${WebUIBucket}/*
               Principal: "*"
 
-  CloudFrontOriginAccessIdentity:
-    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+  CloudFrontOAC:
+    Type: AWS::CloudFront::OriginAccessControl
     Condition: WithCloudFront
     Properties:
-      CloudFrontOriginAccessIdentityConfig:
-        Comment: !Ref WebUIBucket
+      OriginAccessControlConfig:
+        Description: S3F2 Web UI
+        Name: !Sub "${ResourcePrefix}-WebUI-OAC"
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
 
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
@@ -103,8 +110,8 @@ Resources:
         Origins:
           - DomainName: !GetAtt WebUIBucket.RegionalDomainName
             Id: !Sub ${ResourcePrefix}-myS3Origin
-            S3OriginConfig:
-              OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}
+            OriginAccessControlId: !Ref CloudFrontOAC
+            S3OriginConfig: {}
         Enabled: true
         HttpVersion: http2
         Comment: The Distribution for Amazon S3 Find and Forget


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

**Update CloudFront to use OAC instead of OAI**

This change updates the Web UI CloudFront distribution to use Origin
Access Control (OAC) for authentication to the S3 origin, instead of the
previous implementation using Origin Access Identity (OAI).

OAC was introduced in August 2022 to supersede OAI. The main benefit of
this change in S3F2 is that OAI is not supported in AWS regions launched
after December 2022, so this change will be necessary to add region
support in the future.

**Bump cfn-lint version**

This is necessary to add support for CloudFront Origin Access Control
parameter/types.

Also adds an ignore rule for cfn-lint rule W3002, which "warn(s) when
properties are configured to only work with the package command".


*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
