### PR TITLE
Fix codepipeline build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
-## v0.60 (unreleased)
+## v0.60
 
+- [#367](https://github.com/awslabs/amazon-s3-find-and-forget/pull/367): Fix
+  deployment issue caused by deprecation of polling-based S3 sources in AWS
+  CodePipeline
 - [#366](https://github.com/awslabs/amazon-s3-find-and-forget/pull/366): Upgrade
   backend and frontend dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ deploy-vpc:
 
 deploy-cfn:
 	aws cloudformation package --template-file templates/template.yaml --s3-bucket $(TEMP_BUCKET) --output-template-file packaged.yaml
-	aws cloudformation deploy --template-file ./packaged.yaml --stack-name S3F22 --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
+	aws cloudformation deploy --template-file ./packaged.yaml --stack-name S3F2 --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
 		--parameter-overrides CreateCloudFrontDistribution=true EnableContainerInsights=true AdminEmail=$(ADMIN_EMAIL) \
-		AccessControlAllowOriginOverride=* PreBuiltArtefactsBucketOverride=$(TEMP_BUCKET) KMSKeyArns=$(KMS_KEYARNS) ResourcePrefix=S3F22
+		AccessControlAllowOriginOverride=* PreBuiltArtefactsBucketOverride=$(TEMP_BUCKET) KMSKeyArns=$(KMS_KEYARNS)
 
 deploy-artefacts:
 	$(eval VERSION := $(shell $(MAKE) -s version))

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ deploy-vpc:
 
 deploy-cfn:
 	aws cloudformation package --template-file templates/template.yaml --s3-bucket $(TEMP_BUCKET) --output-template-file packaged.yaml
-	aws cloudformation deploy --template-file ./packaged.yaml --stack-name S3F2 --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
+	aws cloudformation deploy --template-file ./packaged.yaml --stack-name S3F22 --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
 		--parameter-overrides CreateCloudFrontDistribution=true EnableContainerInsights=true AdminEmail=$(ADMIN_EMAIL) \
-		AccessControlAllowOriginOverride=* PreBuiltArtefactsBucketOverride=$(TEMP_BUCKET) KMSKeyArns=$(KMS_KEYARNS)
+		AccessControlAllowOriginOverride=* PreBuiltArtefactsBucketOverride=$(TEMP_BUCKET) KMSKeyArns=$(KMS_KEYARNS) ResourcePrefix=S3F22
 
 deploy-artefacts:
 	$(eval VERSION := $(shell $(MAKE) -s version))

--- a/backend/lambdas/custom_resources/rerun_pipeline.py
+++ b/backend/lambdas/custom_resources/rerun_pipeline.py
@@ -19,12 +19,19 @@ def delete(event, context):
 @helper.update
 def update(event, context):
     props = event["ResourceProperties"]
-    props_old = event["OldResourceProperties"]
+    props_old = event.get("OldResourceProperties", {})
 
     deploy_ui_changed = (
-        props_old["DeployWebUI"] == "false" and props["DeployWebUI"] == "true"
+        "DeployWebUI" in props_old
+        and props_old["DeployWebUI"] == "false"
+        and props["DeployWebUI"] == "true"
     )
-    new_version = not "Version" in props_old or props_old["Version"] != props["Version"]
+
+    new_version = (
+        (not "Version" in props_old or props_old["Version"] != props["Version"])
+        if "Version" in props
+        else "Version" in props_old
+    )
 
     if deploy_ui_changed or new_version:
         pipe_client.start_pipeline_execution(name=props["PipelineName"])

--- a/backend/lambdas/custom_resources/rerun_pipeline.py
+++ b/backend/lambdas/custom_resources/rerun_pipeline.py
@@ -19,9 +19,7 @@ def create(event, context):
 @helper.update
 def update(event, context):
     props = event["ResourceProperties"]
-    props_old = event["OldResourceProperties"]
-    if props_old["DeployWebUI"] == "false" and props["DeployWebUI"] == "true":
-        pipe_client.start_pipeline_execution(name=props["PipelineName"])
+    pipe_client.start_pipeline_execution(name=props["PipelineName"])
     return None
 
 

--- a/backend/lambdas/custom_resources/rerun_pipeline.py
+++ b/backend/lambdas/custom_resources/rerun_pipeline.py
@@ -9,17 +9,26 @@ pipe_client = boto3.client("codepipeline")
 
 
 @with_logging
-@helper.create
 @helper.delete
-def create(event, context):
+def delete(event, context):
     return None
 
 
 @with_logging
+@helper.create
 @helper.update
 def update(event, context):
     props = event["ResourceProperties"]
-    pipe_client.start_pipeline_execution(name=props["PipelineName"])
+    props_old = event["OldResourceProperties"]
+
+    deploy_ui_changed = (
+        props_old["DeployWebUI"] == "false" and props["DeployWebUI"] == "true"
+    )
+    new_version = not "Version" in props_old or props_old["Version"] != props["Version"]
+
+    if deploy_ui_changed or new_version:
+        pipe_client.start_pipeline_execution(name=props["PipelineName"])
+
     return None
 
 

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -294,6 +294,31 @@ Resources:
                 Action: codepipeline:StartPipelineExecution
                 Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${CodePipeline}
 
+  AmazonCloudWatchEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.s3
+        detail-type:
+          - 'AWS API Call via CloudTrail'
+        detail:
+          eventSource:
+            - s3.amazonaws.com
+          eventName:
+            - CopyObject
+            - PutObject
+            - CompleteMultipartUpload
+          requestParameters:
+            bucketName:
+              - !Ref CodeBuildArtefactBucket
+            key:
+              - !Ref ArtefactName
+      Targets:
+        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${CodePipeline}
+          RoleArn: !GetAtt AmazonCloudWatchEventRole.Arn
+          Id: codepipeline-AppPipeline
+
   CodePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
@@ -313,6 +338,7 @@ Resources:
               Configuration:
                 S3Bucket: !Ref CodeBuildArtefactBucket
                 S3ObjectKey: !Ref ArtefactName
+                PollForSourceChanges: false
               OutputArtifacts:
                 - Name: S3F2
               RunOrder: 1

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -319,6 +319,53 @@ Resources:
           RoleArn: !GetAtt AmazonCloudWatchEventRole.Arn
           Id: codepipeline-AppPipeline
 
+  AWSCloudTrailBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AWSCloudTrailBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AWSCloudTrailAclCheck
+            Effect: Allow
+            Principal:
+              Service:
+                - cloudtrail.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt AWSCloudTrailBucket.Arn
+          - Sid: AWSCloudTrailWrite
+            Effect: Allow
+            Principal:
+              Service:
+                - cloudtrail.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub ${AWSCloudTrailBucket.Arn}/AWSLogs/${AWS::AccountId}/*
+            Condition: 
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+
+  AWSCloudTrailBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain #TODO
+    #TODO
+
+  AwsCloudTrail:
+    DependsOn:
+      - AWSCloudTrailBucketPolicy
+    Type: AWS::CloudTrail::Trail
+    Properties:
+      S3BucketName: !Ref AWSCloudTrailBucket
+      EventSelectors:
+        - DataResources:
+            - Type: AWS::S3::Object
+              Values:
+                - !Sub ${CodeBuildArtefactBucket}/${ArtefactName}
+          ReadWriteType: WriteOnly
+          IncludeManagementEvents: false
+      IncludeGlobalServiceEvents: true
+      IsLogging: true
+      IsMultiRegionTrail: true
+
   CodePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -274,6 +274,26 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
 
+  AmazonCloudWatchEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: cwe-pipeline-execution
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${CodePipeline}
+
   CodePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -224,148 +224,6 @@ Resources:
       Name: !Sub ${ResourcePrefix}FrontendBuild
       ServiceRole: !Ref CodeBuildFrontendServiceRole
 
-  CodePipelineServiceRole:
-    Type: AWS::IAM::Role
-    Properties:
-      Path: /
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: codepipeline.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: root
-          PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Resource: "*"
-                Action:
-                  - ecs:DescribeServices
-                  - ecs:DescribeTaskDefinition
-                  - ecs:DescribeTasks
-                  - ecs:ListTasks
-                  - ecs:RegisterTaskDefinition
-                  - ecs:UpdateService
-              - Effect: Allow
-                Resource:
-                  - !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/${CodeBuildBackend}
-                Action:
-                  - codebuild:BatchGetBuilds
-                  - codebuild:StartBuild
-              - !If
-                - ShouldDeployWebUI
-                - Effect: Allow
-                  Resource:
-                    - !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/${CodeBuildFrontend}
-                  Action:
-                    - codebuild:BatchGetBuilds
-                    - codebuild:StartBuild
-                - !Ref AWS::NoValue
-              - Effect: Allow
-                Resource: !Sub arn:${AWS::Partition}:s3:::${CodeBuildArtefactBucket}
-                Action:
-                  - s3:GetBucket*
-                  - s3:List*
-              - Effect: Allow
-                Resource: !Sub arn:${AWS::Partition}:s3:::${CodeBuildArtefactBucket}/*
-                Action:
-                  - s3:GetObject
-                  - s3:GetObjectVersion
-                  - s3:PutObject
-
-  AmazonCloudWatchEventRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: events.amazonaws.com
-            Action: sts:AssumeRole
-      Path: /
-      Policies:
-        - PolicyName: cwe-pipeline-execution
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action: codepipeline:StartPipelineExecution
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${CodePipeline}
-
-  AmazonCloudWatchEventRule:
-    Type: AWS::Events::Rule
-    Properties:
-      EventPattern:
-        source:
-          - aws.s3
-        detail-type:
-          - 'AWS API Call via CloudTrail'
-        detail:
-          eventSource:
-            - s3.amazonaws.com
-          eventName:
-            - CopyObject
-            - PutObject
-            - CompleteMultipartUpload
-          requestParameters:
-            bucketName:
-              - !Ref CodeBuildArtefactBucket
-            key:
-              - !Ref ArtefactName
-      Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${CodePipeline}
-          RoleArn: !GetAtt AmazonCloudWatchEventRole.Arn
-          Id: codepipeline-AppPipeline
-
-  AWSCloudTrailBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref AWSCloudTrailBucket
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: AWSCloudTrailAclCheck
-            Effect: Allow
-            Principal:
-              Service:
-                - cloudtrail.amazonaws.com
-            Action: s3:GetBucketAcl
-            Resource: !GetAtt AWSCloudTrailBucket.Arn
-          - Sid: AWSCloudTrailWrite
-            Effect: Allow
-            Principal:
-              Service:
-                - cloudtrail.amazonaws.com
-            Action: s3:PutObject
-            Resource: !Sub ${AWSCloudTrailBucket.Arn}/AWSLogs/${AWS::AccountId}/*
-            Condition: 
-              StringEquals:
-                s3:x-amz-acl: bucket-owner-full-control
-
-  AWSCloudTrailBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain #TODO
-    #TODO
-
-  AwsCloudTrail:
-    DependsOn:
-      - AWSCloudTrailBucketPolicy
-    Type: AWS::CloudTrail::Trail
-    Properties:
-      S3BucketName: !Ref AWSCloudTrailBucket
-      EventSelectors:
-        - DataResources:
-            - Type: AWS::S3::Object
-              Values:
-                - !Sub ${CodeBuildArtefactBucket}/${ArtefactName}
-          ReadWriteType: WriteOnly
-          IncludeManagementEvents: false
-      IncludeGlobalServiceEvents: true
-      IsLogging: true
-      IsMultiRegionTrail: true
-
   CodePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
@@ -566,7 +424,7 @@ Resources:
 
   WaitForContainerBuild:
     Type: Custom::Setup
-    DependsOn: CopyBuildArtefact
+    DependsOn: RerunPipeline
     Properties:
       ServiceToken: !GetAtt WaitForContainerBuildFunction.Arn
       ArtefactName: !Ref ArtefactName
@@ -588,6 +446,7 @@ Resources:
 
   RerunPipeline:
     Type: Custom::Setup
+    DependsOn: CopyBuildArtefact
     Properties:
       ServiceToken: !GetAtt RerunPipelineFunction.Arn
       LogLevel: !Ref LogLevel

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -223,6 +223,56 @@ Resources:
             Value: !Ref WebUIBucket
       Name: !Sub ${ResourcePrefix}FrontendBuild
       ServiceRole: !Ref CodeBuildFrontendServiceRole
+  
+  CodePipelineServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Resource: "*"
+                Action:
+                  - ecs:DescribeServices
+                  - ecs:DescribeTaskDefinition
+                  - ecs:DescribeTasks
+                  - ecs:ListTasks
+                  - ecs:RegisterTaskDefinition
+                  - ecs:UpdateService
+              - Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/${CodeBuildBackend}
+                Action:
+                  - codebuild:BatchGetBuilds
+                  - codebuild:StartBuild
+              - !If
+                - ShouldDeployWebUI
+                - Effect: Allow
+                  Resource:
+                    - !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/${CodeBuildFrontend}
+                  Action:
+                    - codebuild:BatchGetBuilds
+                    - codebuild:StartBuild
+                - !Ref AWS::NoValue
+              - Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:s3:::${CodeBuildArtefactBucket}
+                Action:
+                  - s3:GetBucket*
+                  - s3:List*
+              - Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:s3:::${CodeBuildArtefactBucket}/*
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
 
   CodePipeline:
     Type: AWS::CodePipeline::Pipeline
@@ -386,7 +436,6 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${CodePipeline}
 
-
   CleanupCodeBuildArtefactBucket:
     Type: Custom::Setup
     Properties:
@@ -424,7 +473,7 @@ Resources:
 
   WaitForContainerBuild:
     Type: Custom::Setup
-    DependsOn: RerunPipeline
+    DependsOn: CopyBuildArtefact
     Properties:
       ServiceToken: !GetAtt WaitForContainerBuildFunction.Arn
       ArtefactName: !Ref ArtefactName
@@ -432,7 +481,6 @@ Resources:
       ECRRepository: !Ref ECRRepository
       LogLevel: !Ref LogLevel
       Version: !Ref Version
-
 
   RedeployApi:
     Type: Custom::Setup
@@ -442,7 +490,6 @@ Resources:
       ApiId: !Select [0, !Split [".", !Select [2, !Split ["/", !Ref ApiUrl]]]]
       ApiStage: !Select [3, !Split ["/", !Ref ApiUrl]]
       DeployCognito: !Ref DeployCognito
-
 
   RerunPipeline:
     Type: Custom::Setup

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -499,3 +499,4 @@ Resources:
       LogLevel: !Ref LogLevel
       PipelineName: !Ref CodePipeline
       DeployWebUI: !Ref DeployWebUI
+      Version: !Ref Version

--- a/templates/deployment_helper.yaml
+++ b/templates/deployment_helper.yaml
@@ -473,7 +473,7 @@ Resources:
 
   WaitForContainerBuild:
     Type: Custom::Setup
-    DependsOn: CopyBuildArtefact
+    DependsOn: RerunPipeline
     Properties:
       ServiceToken: !GetAtt WaitForContainerBuildFunction.Arn
       ArtefactName: !Ref ArtefactName

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.59)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.60)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.59'
+      Version: 'v0.60'
 
 Resources:
   TempBucket:

--- a/tests/unit/crs/test_cr_rerun_pipeline.py
+++ b/tests/unit/crs/test_cr_rerun_pipeline.py
@@ -30,7 +30,7 @@ def test_it_triggers_execution_if_new_version(mock_client):
         "ResourceProperties": {
             "DeployWebUI": "true",
             "PipelineName": "pipeline",
-            "Version": "v0.60",
+            "Version": "v0.62",
         },
         "OldResourceProperties": {"DeployWebUI": "true", "Version": "v0.61"},
     }
@@ -53,6 +53,44 @@ def test_it_triggers_execution_if_new_version_old_signature(mock_client):
         "OldResourceProperties": {
             "DeployWebUI": "true"
         },  # Prior to 0.59, the Version parameter wasn't sent to the CR payload
+    }
+
+    resp = update(event, MagicMock())
+
+    mock_client.start_pipeline_execution.assert_called_with(name="pipeline")
+
+    assert not resp
+
+
+@patch("backend.lambdas.custom_resources.rerun_pipeline.pipe_client")
+def test_it_triggers_execution_if_rollback_to_old_signature(mock_client):
+    event = {
+        "ResourceProperties": {
+            "DeployWebUI": "true",
+            "PipelineName": "pipeline",
+            # Prior to 0.59, the Version parameter wasn't sent to the CR payload
+        },
+        "OldResourceProperties": {
+            "DeployWebUI": "true",
+            "Version": "v0.60",
+        },
+    }
+
+    resp = update(event, MagicMock())
+
+    mock_client.start_pipeline_execution.assert_called_with(name="pipeline")
+
+    assert not resp
+
+
+@patch("backend.lambdas.custom_resources.rerun_pipeline.pipe_client")
+def test_it_triggers_execution_if_new_stack(mock_client):
+    event = {
+        "ResourceProperties": {
+            "DeployWebUI": "true",
+            "PipelineName": "pipeline",
+            "Version": "v0.60",
+        }
     }
 
     resp = update(event, MagicMock())

--- a/tests/unit/crs/test_cr_rerun_pipeline.py
+++ b/tests/unit/crs/test_cr_rerun_pipeline.py
@@ -1,16 +1,58 @@
 import pytest
 from mock import patch, MagicMock
 
-from backend.lambdas.custom_resources.rerun_pipeline import create, update, handler
+from backend.lambdas.custom_resources.rerun_pipeline import delete, update, handler
 
 pytestmark = [pytest.mark.unit, pytest.mark.task]
 
 
 @patch("backend.lambdas.custom_resources.rerun_pipeline.pipe_client")
-def test_it_triggers_execution_if_required(mock_client):
+def test_it_triggers_execution_if_web_ui_setting_changes(mock_client):
     event = {
-        "ResourceProperties": {"DeployWebUI": "true", "PipelineName": "pipeline"},
-        "OldResourceProperties": {"DeployWebUI": "false"},
+        "ResourceProperties": {
+            "DeployWebUI": "true",
+            "PipelineName": "pipeline",
+            "Version": "v0.60",
+        },
+        "OldResourceProperties": {"DeployWebUI": "false", "Version": "v0.60"},
+    }
+
+    resp = update(event, MagicMock())
+
+    mock_client.start_pipeline_execution.assert_called_with(name="pipeline")
+
+    assert not resp
+
+
+@patch("backend.lambdas.custom_resources.rerun_pipeline.pipe_client")
+def test_it_triggers_execution_if_new_version(mock_client):
+    event = {
+        "ResourceProperties": {
+            "DeployWebUI": "true",
+            "PipelineName": "pipeline",
+            "Version": "v0.60",
+        },
+        "OldResourceProperties": {"DeployWebUI": "true", "Version": "v0.61"},
+    }
+
+    resp = update(event, MagicMock())
+
+    mock_client.start_pipeline_execution.assert_called_with(name="pipeline")
+
+    assert not resp
+
+
+@patch("backend.lambdas.custom_resources.rerun_pipeline.pipe_client")
+def test_it_triggers_execution_if_new_version_old_signature(mock_client):
+    event = {
+        "ResourceProperties": {
+            "DeployWebUI": "true",
+            "PipelineName": "pipeline",
+            "Version": "v0.60",
+        },
+        "OldResourceProperties": {
+            "DeployWebUI": "true"
+        },  # Prior to 0.59, the Version parameter wasn't sent to the CR payload
     }
 
     resp = update(event, MagicMock())
@@ -23,8 +65,8 @@ def test_it_triggers_execution_if_required(mock_client):
 @patch("backend.lambdas.custom_resources.rerun_pipeline.pipe_client")
 def test_it_does_not_trigger_execution_if_not_required(mock_client):
     event = {
-        "ResourceProperties": {"DeployWebUI": "false"},
-        "OldResourceProperties": {"DeployWebUI": "false"},
+        "ResourceProperties": {"DeployWebUI": "false", "Version": "v0.60"},
+        "OldResourceProperties": {"DeployWebUI": "false", "Version": "v0.60"},
     }
 
     resp = update(event, MagicMock())
@@ -35,8 +77,8 @@ def test_it_does_not_trigger_execution_if_not_required(mock_client):
 
 
 @patch("backend.lambdas.custom_resources.rerun_pipeline.pipe_client")
-def test_it_does_nothing_on_create(mock_client):
-    resp = create({}, MagicMock())
+def test_it_does_nothing_on_delete(mock_client):
+    resp = delete({}, MagicMock())
 
     mock_client.assert_not_called()
     assert not resp


### PR DESCRIPTION
*Issue #, if available:*

Starting May 25, 2023, CodePipeline doesn't allow anymore polling based S3 sources. New stacks don't poll, and existing stacks with pipelines that haven't ran for more than 30 days, don't start a build when a S3 source is uploaded. As a consequence:
1. New builds of this solution are currently stuck on the "Wait for Container Build" custom resource, as the build never starts
2. Existing deployments of this solution cannot be updated for the same issue.

*Description of changes:*

There is [a (quite convoluted) way to setup Eventbridge to start a deployment, based on CloudTrail and setting up lots of resources](https://docs.aws.amazon.com/codepipeline/latest/userguide/update-change-detection.html#update-change-detection-S3), but we already have a Custom Resource Lambda to start the build, previously used to update stacks whenever the "Deploy Frontend" setting changed on top of an existing deployment. So, I opted to change it to be executed on stack creation as well as updates, and whenever a new version is published. 

I tested this change by updating an existing stack, as well as creating a new stack.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
