### PR TITLE
Add the deployment region to OAC Name property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.61
+
+- [#368](https://github.com/awslabs/amazon-s3-find-and-forget/issues/368): Fix
+  an issue that prevented deployments for users who have multiple S3F2 instances
+  deployed within the same AWS account, using the same ResourcePrefix parameter,
+  but in different regions.
+
 ## v0.60
 
 - [#367](https://github.com/awslabs/amazon-s3-find-and-forget/pull/367): Fix

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -261,7 +261,8 @@ resources.
      Bucket containing Front-end and Back-end pre-built artefacts. Use this if
      you are using a customised version of these artefacts.
    - **ResourcePrefix:** (Default: S3F2) Resource prefix to apply to resource
-     names when creating statically named resources.
+     names when creating statically named resources. Change this when deploying
+     multiple instances of the solution within an AWS account.
    - **KMSKeyArns** (Default: "") Comma-delimited list of KMS Key Arns used for
      Client-side Encryption. Leave empty if data is not client-side encrypted
      with KMS.

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.60)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.61)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.60'
+      Version: 'v0.61'
 
 Resources:
   TempBucket:

--- a/templates/web_ui.yaml
+++ b/templates/web_ui.yaml
@@ -97,7 +97,7 @@ Resources:
     Properties:
       OriginAccessControlConfig:
         Description: S3F2 Web UI
-        Name: !Sub "${ResourcePrefix}-WebUI-OAC"
+        Name: !Sub "${ResourcePrefix}-${AWS::Region}-WebUI-OAC"
         OriginAccessControlOriginType: s3
         SigningBehavior: always
         SigningProtocol: sigv4


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This fixes an issue introduced in
995f9d90bc3049e8a77490bc15fa23d1b785b900 that affected users who have
multiple S3F2 instances deployed within the same AWS account, using the
same ResourcePrefix parameter, but in different regions.

The issue prevented the stack from deploying because CloudFront
resources are global (not namespaced to a region), and the name must be
unique within an AWS account.

Note, for multiple deployments within an account we'd recommend using
a different ResourcePrefix, but we are fixing this as it worked in
previous releases. Added this to the deployment docs.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
