### PR TITLE
Fix for a bug affecting gzip json being writtern in uncompressed format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+fail_fast: true
 repos:
 -   repo: local
     hooks:
@@ -5,30 +6,35 @@ repos:
         name: Format CloudFormation
         entry: make format-cfn
         language: system
+        files: ^templates/
 -   repo: local
     hooks:
     -   id: format-js
         name: Format Javascript
         entry: make format-js
         language: system
+        files: ^frontend/
 -   repo: local
     hooks:
     -   id: format-python
         name: Format Python Code
         entry: make format-python
         language: system
+        files: ^backend/
 -   repo: local
     hooks:
     -   id: format-docs
         name: Format Markdown docs
         entry: make format-docs
         language: system
+        files: .*\.md
 -   repo: local
     hooks:
     -   id: generate-api-docs
         name: Generate API Docs
         entry: make generate-api-docs
         language: system
+        files: ^templates/api.yaml
 -   repo: https://github.com/awslabs/git-secrets
     rev: 5e28df337746db4f070c84f7069d365bfd0d72a8
     hooks:
@@ -39,3 +45,4 @@ repos:
         name: Lint CloudFormation templates
         entry: make lint-cfn
         language: system
+        files: ^templates/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v0.63 (unreleased)
+## v0.63
 
 - [#376](https://github.com/awslabs/amazon-s3-find-and-forget/issues/376):
   Upgrade backend dependencies
@@ -8,6 +8,10 @@
   Upgrade backend dependencies
 - [#383](https://github.com/awslabs/amazon-s3-find-and-forget/issues/383):
   Upgrade backend dependencies
+- [#384](https://github.com/awslabs/amazon-s3-find-and-forget/issues/384):
+  - Fix an issue impacting JSON Gzipped S3 objects being written uncompressed
+    after a deletion Job
+  - Upgrade backend dependencies
 
 ## v0.62
 

--- a/backend/ecs_tasks/delete_files/requirements.in
+++ b/backend/ecs_tasks/delete_files/requirements.in
@@ -1,4 +1,4 @@
-pyarrow==8.0.0
+pyarrow==13.0.0
 python-snappy==0.6.1
 pandas==1.4.3
 boto3==1.24.38

--- a/backend/ecs_tasks/delete_files/requirements.txt
+++ b/backend/ecs_tasks/delete_files/requirements.txt
@@ -29,7 +29,7 @@ numpy==1.22.0
     #   pyarrow
 pandas==1.4.3
     # via -r backend/ecs_tasks/delete_files/requirements.in
-pyarrow==8.0.0
+pyarrow==13.0.0
     # via -r backend/ecs_tasks/delete_files/requirements.in
 pycparser==2.21
     # via cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,7 +132,7 @@ pluggy==1.0.0
     # via pytest
 pre-commit==2.12.1
     # via -r requirements.in
-pyarrow==8.0.0
+pyarrow==13.0.0
     # via -r ./backend/ecs_tasks/delete_files/requirements.txt
 pycparser==2.21
     # via

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.62) (tag:main)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.63) (tag:main)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.62'
+      Version: 'v0.63'
 
 Resources:
   TempBucket:

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -1,3 +1,4 @@
+import gzip
 import logging
 import tempfile
 from pathlib import Path
@@ -48,6 +49,11 @@ def generate_parquet_file(items, columns):
 def query_parquet_file(f, column, val):
     table = pq.read_table(f)
     return [i for i in table.column(column) if i.as_py() == val]
+
+
+def query_compressed_json_file(f, column, val):
+    f_gz = gzip.open(f, "rb")
+    return query_json_file(f_gz, column, val)
 
 
 def query_json_file(f, column, val):

--- a/tests/acceptance/test_job_cognito.py
+++ b/tests/acceptance/test_job_cognito.py
@@ -6,7 +6,12 @@ import mock
 import pytest
 from decimal import Decimal
 
-from tests.acceptance import query_json_file, query_parquet_file, download_and_decrypt
+from tests.acceptance import (
+    query_json_file,
+    query_compressed_json_file,
+    query_parquet_file,
+    download_and_decrypt,
+)
 
 pytestmark = [
     pytest.mark.acceptance_cognito,
@@ -539,9 +544,10 @@ def test_it_runs_for_gzip_json_happy_path(
         "COMPLETED"
         == job_table.get_item(Key={"Id": job_id, "Sk": job_id})["Item"]["JobStatus"]
     )
-    assert 0 == len(query_json_file(tmp.name, "customer_id", "12345"))
-    assert 1 == len(query_json_file(tmp.name, "customer_id", "23456"))
-    assert 1 == len(query_json_file(tmp.name, "customer_id", "34567"))
+
+    assert 0 == len(query_compressed_json_file(tmp.name, "customer_id", "12345"))
+    assert 1 == len(query_compressed_json_file(tmp.name, "customer_id", "23456"))
+    assert 1 == len(query_compressed_json_file(tmp.name, "customer_id", "34567"))
     assert 2 == len(list(bucket.object_versions.filter(Prefix=object_key)))
     assert {"foo": "bar"} == bucket.Object(object_key).metadata
     assert "cache" == bucket.Object(object_key).cache_control

--- a/tests/acceptance/test_job_iam.py
+++ b/tests/acceptance/test_job_iam.py
@@ -6,7 +6,12 @@ import mock
 import pytest
 from decimal import Decimal
 
-from tests.acceptance import query_json_file, query_parquet_file, download_and_decrypt
+from tests.acceptance import (
+    query_json_file,
+    query_compressed_json_file,
+    query_parquet_file,
+    download_and_decrypt,
+)
 
 pytestmark = [
     pytest.mark.acceptance_iam,
@@ -529,9 +534,9 @@ def test_it_runs_for_gzip_json_happy_path(
         "COMPLETED"
         == job_table.get_item(Key={"Id": job_id, "Sk": job_id})["Item"]["JobStatus"]
     )
-    assert 0 == len(query_json_file(tmp.name, "customer_id", "12345"))
-    assert 1 == len(query_json_file(tmp.name, "customer_id", "23456"))
-    assert 1 == len(query_json_file(tmp.name, "customer_id", "34567"))
+    assert 0 == len(query_compressed_json_file(tmp.name, "customer_id", "12345"))
+    assert 1 == len(query_compressed_json_file(tmp.name, "customer_id", "23456"))
+    assert 1 == len(query_compressed_json_file(tmp.name, "customer_id", "34567"))
     assert 2 == len(list(bucket.object_versions.filter(Prefix=object_key)))
     assert {"foo": "bar"} == bucket.Object(object_key).metadata
     assert "cache" == bucket.Object(object_key).cache_control

--- a/tests/unit/ecs_tasks/test_main.py
+++ b/tests/unit/ecs_tasks/test_main.py
@@ -91,7 +91,7 @@ def test_happy_path_when_queue_not_empty(
     mock_fs.open_input_stream.assert_called_with(
         "bucket/path/basic.parquet", buffer_size=5 * 2**20
     )
-    mock_delete.assert_called_with(ANY, [column], "parquet")
+    mock_delete.assert_called_with(ANY, [column], "parquet", False)
     mock_save.assert_called_with(ANY, ANY, "bucket", "path/basic.parquet", {}, "abc123")
     mock_emit.assert_called()
     mock_session.assert_called_with(None, "s3f2")
@@ -146,7 +146,7 @@ def test_happy_path_when_queue_not_empty_for_compressed_json(
     mock_fs.open_input_stream.assert_called_with(
         "bucket/path/basic.json.gz", buffer_size=5 * 2**20
     )
-    mock_delete.assert_called_with(ANY, [column], "json")
+    mock_delete.assert_called_with(ANY, [column], "json", True)
     mock_save.assert_called_with(ANY, ANY, "bucket", "path/basic.json.gz", {}, "abc123")
     mock_emit.assert_called()
     mock_session.assert_called_with(None, "s3f2")
@@ -216,7 +216,7 @@ def test_cse_kms_encrypted(
     mock_fs.open_input_stream.assert_called_with(
         "bucket/path/basic.parquet", buffer_size=5 * 2**20
     )
-    mock_delete.assert_called_with(mock_file_decrypted, [column], "parquet")
+    mock_delete.assert_called_with(mock_file_decrypted, [column], "parquet", False)
     mock_encrypt.assert_called_with(ANY, metadata, ANY)
     mock_save.assert_called_with(
         ANY,
@@ -1105,8 +1105,8 @@ def test_it_sets_kill_handlers(mock_queue, mock_signal):
 def test_it_deletes_from_json_file(mock_parquet, mock_json):
     f = MagicMock()
     cols = MagicMock()
-    delete_matches_from_file(f, cols, "json")
-    mock_json.assert_called_with(f, cols)
+    delete_matches_from_file(f, cols, "json", False)
+    mock_json.assert_called_with(f, cols, False)
     mock_parquet.assert_not_called()
 
 


### PR DESCRIPTION
*Description of changes:*

Fix for a bug affecting gz json introduced in #358. It affected JSON gzipped objects, and the issue is that they are being written uncompressed. 

There are a couple of additional improvements included in this PR:
1. optimisations on Pre-commit hooks to run faster
2. Upgrade Apache Arrow from v8 to v13.


*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
