### PR TITLE
Parametersless metadata bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.65
 
-- [#TODO](https://github.com/awslabs/amazon-s3-find-and-forget/issues/TODO): Fix
+- [#393](https://github.com/awslabs/amazon-s3-find-and-forget/issues/393): Fix
   for a bug affecting Create Data Mapper API with manually created Glue Tables
   that don't contain SerdeInfo Parameters metadata
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.65
+
+- [#TODO](https://github.com/awslabs/amazon-s3-find-and-forget/issues/TODO): Fix
+  for a bug affecting Create Data Mapper API with manually created Glue Tables
+  that don't contain SerdeInfo Parameters metadata
+
 ## v0.64
 
 - [#390](https://github.com/awslabs/amazon-s3-find-and-forget/issues/390):

--- a/backend/lambdas/data_mappers/handlers.py
+++ b/backend/lambdas/data_mappers/handlers.py
@@ -167,8 +167,8 @@ def get_glue_table_location(t):
 
 def get_glue_table_format(t):
     return (
-        t["Table"]["StorageDescriptor"]["SerdeInfo"]["SerializationLibrary"],
-        t["Table"]["StorageDescriptor"]["SerdeInfo"]["Parameters"],
+        t["Table"]["StorageDescriptor"]["SerdeInfo"].get("SerializationLibrary", ""),
+        t["Table"]["StorageDescriptor"]["SerdeInfo"].get("Parameters", {}),
     )
 
 

--- a/backend/lambdas/data_mappers/handlers.py
+++ b/backend/lambdas/data_mappers/handlers.py
@@ -166,9 +166,10 @@ def get_glue_table_location(t):
 
 
 def get_glue_table_format(t):
+    serde_info = t["Table"].get("StorageDescriptor", {}).get("SerdeInfo", {})
     return (
-        t["Table"]["StorageDescriptor"]["SerdeInfo"].get("SerializationLibrary", ""),
-        t["Table"]["StorageDescriptor"]["SerdeInfo"].get("Parameters", {}),
+        serde_info.get("SerializationLibrary", ""),
+        serde_info.get("Parameters", {}),
     )
 
 

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.64) (tag:main)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.65) (tag:main)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.64'
+      Version: 'v0.65'
 
 Resources:
   TempBucket:

--- a/tests/unit/data_mappers/test_data_mappers.py
+++ b/tests/unit/data_mappers/test_data_mappers.py
@@ -566,17 +566,11 @@ def test_it_gets_glue_table_parametersless():
                 "Location": "s3://bucket/",
                 "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
                 "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
-                "SerdeInfo": {
-                    "SerializationLibrary": "org.openx.data.jsonserde.JsonSerDe"
-                },
-            },
-            "PartitionKeys": [],
+            }
         }
     }
 
-    assert ("org.openx.data.jsonserde.JsonSerDe", {}) == handlers.get_glue_table_format(
-        table
-    )
+    assert ("", {}) == handlers.get_glue_table_format(table)
 
 
 @patch("backend.lambdas.data_mappers.handlers.glue_client")

--- a/tests/unit/data_mappers/test_data_mappers.py
+++ b/tests/unit/data_mappers/test_data_mappers.py
@@ -559,6 +559,26 @@ def test_it_gets_glue_table_format_info():
     ) == handlers.get_glue_table_format(get_table_stub())
 
 
+def test_it_gets_glue_table_parametersless():
+    table = {
+        "Table": {
+            "StorageDescriptor": {
+                "Location": "s3://bucket/",
+                "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+                "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                "SerdeInfo": {
+                    "SerializationLibrary": "org.openx.data.jsonserde.JsonSerDe"
+                },
+            },
+            "PartitionKeys": [],
+        }
+    }
+
+    assert ("org.openx.data.jsonserde.JsonSerDe", {}) == handlers.get_glue_table_format(
+        table
+    )
+
+
 @patch("backend.lambdas.data_mappers.handlers.glue_client")
 def test_it_gets_details_for_table(mock_client):
     mock_client.get_table.return_value = get_table_stub()


### PR DESCRIPTION
*Description of changes:*

When Glue Tables are created manually, SerdeInfo/Parameters metadata can be omitted, breaking the validation logic in the Create Data Mapper API. This change fixes that by checking for Parameters metadata existence first.

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
