### PR TITLE
Replace Managed Policy with equivalent inline policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Change Log
 
+## v0.67
+
+- [#405](https://github.com/awslabs/amazon-s3-find-and-forget/pull/405) Replace
+  AmazonAPIGatewayInvokeFullAccess managed policy with inline policy
+
 ## v0.66
 
 - [#395](https://github.com/awslabs/amazon-s3-find-and-forget/issues/395):
-  Increase the speed of the json_handler by migrating from a list to a set.
-  Move from O(n) to O(1)
+  Increase the speed of the json_handler by migrating from a list to a set. Move
+  from O(n) to O(1)
 
 ## v0.65
 

--- a/templates/auth.yaml
+++ b/templates/auth.yaml
@@ -58,8 +58,6 @@ Resources:
   ServiceInvokeRole:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -93,6 +91,16 @@ Resources:
                   - !Sub "arn:${AWS::Partition}:glue:*:${AWS::AccountId}:database*"
                   - !Sub "arn:${AWS::Partition}:glue:*:${AWS::AccountId}:table*"
                   - !Sub "arn:${AWS::Partition}:glue:*:${AWS::AccountId}:partition*"
+        - PolicyName: APIGateway
+          PolicyDocument: 
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "execute-api:Invoke"
+                  - "execute-api:ManageConnections"
+                Resource: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:*
+         
 
 Outputs:
   CognitoIdentityPoolId:


### PR DESCRIPTION
Some scanners are triggered by the presence of the `AmazonAPIGatewayInvokeFullAccessmanaged` policy. This commit replaces the managed policy with an equivalent inline policy that will not trigger scanners. There's a small security win in being able to scope the API Gateway resource to the specific Account and Region.

*Issue #, if available:*

*Description of changes:*

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
