### PR TITLE
Enable Scan On Push for the ECR Repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.68
+- [#408](https://github.com/awslabs/amazon-s3-find-and-forget/pull/408) Enable 
+  Scan On Push for the ECR Repository
+
 ## v0.67
 
 - [#405](https://github.com/awslabs/amazon-s3-find-and-forget/pull/405) Replace

--- a/templates/deletion_flow.yaml
+++ b/templates/deletion_flow.yaml
@@ -67,6 +67,9 @@ Resources:
 
   ECRRepository:
     Type: AWS::ECR::Repository
+    Properties:
+      ImageScanningConfiguration:
+        ScanOnPush: true
 
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.67) (tag:main)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.68) (tag:main)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.67'
+      Version: 'v0.68'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
Image scanning helps in identifying software vulnerabilities in your container images. Each repository can be configured to scan on push. This ensures that each new image pushed to the repository is scanned. You can then retrieve the results of the image scan. You can learn more [here](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html). When Scan on Push is not enabled, images are not automatically scanned when they are pushed on to the repository. Vulnerabilities in your ECR images can affect the security posture of your containers or any applications running within them. Some scanners are triggered because the ECR repository doesn't enable ScanOnPush. 

*Issue #, if available:*

*Description of changes:*

Enable scan on push for the ECR repository used by the deletion workflow.

*PR Checklist:*

- [x] Changelog updated
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
