### PR TITLE
Bump Docker base image to 3.9-slim-bullseye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v0.69 (unreleased)
+## v0.69
 
 - [#418](https://github.com/awslabs/amazon-s3-find-and-forget/issues/418):
   Upgrade frontend dependencies
@@ -8,8 +8,8 @@
   Upgrade backend dependencies
 - [#422](https://github.com/awslabs/amazon-s3-find-and-forget/issues/422):
   Upgrade frontend dependencies
-- [#424](https://github.com/awslabs/amazon-s3-find-and-forget/issues/424):
-  Bump Docker base image to 3.9-slim-bullseye
+- [#424](https://github.com/awslabs/amazon-s3-find-and-forget/issues/424): Bump
+  Docker base image to 3.9-slim-bullseye
 
 ## v0.68
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   Upgrade backend dependencies
 - [#422](https://github.com/awslabs/amazon-s3-find-and-forget/issues/422):
   Upgrade frontend dependencies
+- [#424](https://github.com/awslabs/amazon-s3-find-and-forget/issues/424):
+  Bump Docker base image to 3.9-slim-bullseye
 
 ## v0.68
 

--- a/backend/ecs_tasks/delete_files/Dockerfile
+++ b/backend/ecs_tasks/delete_files/Dockerfile
@@ -1,7 +1,7 @@
 ARG src_path=backend/ecs_tasks/delete_files
 ARG layers_path=backend/lambda_layers
 
-FROM public.ecr.aws/docker/library/python:3.9.16-slim-bullseye as base
+FROM public.ecr.aws/docker/library/python:3.9-slim-bullseye as base
 
 RUN apt-get update --fix-missing && apt-get -y upgrade
 RUN apt-get -y install g++ gcc libsnappy-dev

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.68) (tag:main)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.69) (tag:main)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.68'
+      Version: 'v0.69'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
The Python Docker image (public.ecr.aws/docker/library/python:3.9.16-slim-bullseye) has critical security vulnerabilities detected by Amazon Elastic Container Registry (ECR) scanner. This image's last update occurred in 2023. To maintain security while preserving compatibility of Python and the image environment, I recommend using the base image tag '3.9-slim-bullseye' instead of '3.9.16-slim-bullseye'. This approach automatically pulls the latest secure version within the 3.9 release series.

*Issue #, if available:*

*Description of changes:*

*PR Checklist:*

- [x] Changelog updated
- [x] Unit tests (and integration tests if applicable) provided
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Debugging code removed
- [x] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
