### PR TITLE
Reverted the eu-south-1 region enablement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change Log
 
+## v0.71
+
+- [#429](https://github.com/awslabs/amazon-s3-find-and-forget/pull/429):
+  Reverted the `eu-south-2` region enablement
+
 ## v0.70
 
 - [#428](https://github.com/awslabs/amazon-s3-find-and-forget/pull/428): Enabled
-  the `eu-south-2` region
+  the `eu-south-2` region, Updated the docker images used for CodeBuild
 
 ## v0.69
 

--- a/cfn-publish.config
+++ b/cfn-publish.config
@@ -2,4 +2,4 @@ bucket_name_prefix="solution-builders"
 acl="public-read"
 extra_files=build.zip
 templates="templates/template.yaml templates/role.yaml"
-regions="us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-south-1 ap-southeast-2 eu-west-1 eu-west-2 eu-central-1 eu-north-1 eu-south-2"
+regions="us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-south-1 ap-southeast-2 eu-west-1 eu-west-2 eu-central-1 eu-north-1"

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -185,7 +185,6 @@ Rules:
           - eu-west-1
           - eu-west-2
           - eu-west-3
-          - eu-south-2
           - me-south-1
           - sa-east-1
           - us-east-1

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.70) (tag:main)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.71) (tag:main)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.70'
+      Version: 'v0.71'
 
 Resources:
   TempBucket:

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -55,8 +55,6 @@ Mappings:
       HasThreeAZs: true
     eu-west-3:
       HasThreeAZs: true
-    eu-south-2:
-      HasThreeAZs: true
     sa-east-1:
       HasThreeAZs: true
     us-east-1:


### PR DESCRIPTION
*Description of changes:*

This PR reverts the enablement of the `eu-south-2` region due to failure in the deployment. Removing the region until we come up with a fix for the deployment.

*PR Checklist:*

- [ ] Changelog updated
- [ ] Unit tests (and integration tests if applicable) provided
- [ ] All tests pass
- [ ] Pre-commit checks pass
- [ ] Debugging code removed
- [ ] If releasing a new version, have you bumped the version in the main CFN template?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
