### PR TITLE
fix(json): delete records with falsy match identifiers (0, "", false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## Unreleased
+
+- Fix the JSON Forget-phase handler so that records whose match identifier is a
+  legitimate falsy JSON value (integer `0`, float `0.0`, empty string `""`, or
+  boolean `false`) are correctly deleted. Previously a truthiness guard
+  short-circuited on these values and silently skipped matching records, which
+  is a GDPR right-to-be-forgotten correctness defect. The guard now uses
+  `is not None` to distinguish an absent key from a falsy-but-present value.
+
 ## v0.76 (2026-07-07)
 
 - [#457](https://github.com/awslabs/amazon-s3-find-and-forget/pull/457): Bump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## Unreleased
 
-- Fix the JSON Forget-phase handler so that records whose match identifier is a
-  legitimate falsy JSON value (integer `0`, float `0.0`, empty string `""`, or
-  boolean `false`) are correctly deleted. Previously a truthiness guard
-  short-circuited on these values and silently skipped matching records, which
-  is a GDPR right-to-be-forgotten correctness defect. The guard now uses
-  `is not None` to distinguish an absent key from a falsy-but-present value.
+- [#453](https://github.com/awslabs/amazon-s3-find-and-forget/pull/453): Fix the
+  JSON Forget-phase handler so that Composite match components (and Simple match
+  IDs) with a falsy value such as `0` or `""` are no longer skipped by the
+  truthiness guard; the comparison now uses `is not None`.
 
 ## v0.76 (2026-07-07)
 

--- a/backend/ecs_tasks/delete_files/json_handler.py
+++ b/backend/ecs_tasks/delete_files/json_handler.py
@@ -52,14 +52,14 @@ def delete_matches_from_json_file(input_file, to_delete, compressed=False):
             for column in to_delete:
                 if column["Type"] == "Simple":
                     record = get_value(column["Column"], parsed)
-                    if record and record in column["MatchIds"]:
+                    if record is not None and record in column["MatchIds"]:
                         should_delete = True
                         break
                 else:
                     matched = []
                     for col in column["Columns"]:
                         record = get_value(col, parsed)
-                        if record:
+                        if record is not None:
                             matched.append(record)
                     if tuple(matched) in column["MatchIds"]:
                         should_delete = True

--- a/tests/unit/ecs_tasks/test_json.py
+++ b/tests/unit/ecs_tasks/test_json.py
@@ -366,6 +366,12 @@ def test_delete_correct_rows_from_json_file_with_falsy_empty_string_identifier()
 
 
 def test_delete_correct_rows_from_json_file_with_falsy_boolean_identifier():
+    # Defensive coverage only: `boolean` is not in ALLOWED_TYPES
+    # (generate_queries.py), so a boolean column can never be selected as a
+    # Match ID identifier and cast_to_type would reject it upstream. This test
+    # pins the handler's falsy-value behavior directly, independent of that
+    # guard, so the `is not None` semantics stay correct if the type rules
+    # ever change.
     # Arrange
     to_delete = [{"Column": "opted_in", "MatchIds": set([False]), "Type": "Simple"}]
     data = (

--- a/tests/unit/ecs_tasks/test_json.py
+++ b/tests/unit/ecs_tasks/test_json.py
@@ -327,6 +327,88 @@ def test_it_throws_meaningful_error_for_serialization_issues():
     )
 
 
+def test_delete_correct_rows_from_json_file_with_falsy_integer_identifier():
+    # Arrange
+    to_delete = [{"Column": "customer_id", "MatchIds": set([0]), "Type": "Simple"}]
+    data = (
+        '{"customer_id": 0, "x": 1.2, "d":"2001-01-01"}\n'
+        '{"customer_id": 1, "x": 2.3, "d":"2001-01-03"}\n'
+        '{"customer_id": 2, "x": 3.4, "d":"2001-01-05"}\n'
+    )
+    out_stream = to_json_file(data)
+    # Act
+    out, stats = delete_matches_from_json_file(out_stream, to_delete)
+    assert isinstance(out, pa.BufferOutputStream)
+    assert {"ProcessedRows": 3, "DeletedRows": 1} == stats
+    assert to_json_string(out) == (
+        '{"customer_id": 1, "x": 2.3, "d":"2001-01-03"}\n'
+        '{"customer_id": 2, "x": 3.4, "d":"2001-01-05"}\n'
+    )
+
+
+def test_delete_correct_rows_from_json_file_with_falsy_empty_string_identifier():
+    # Arrange
+    to_delete = [{"Column": "customer_id", "MatchIds": set([""]), "Type": "Simple"}]
+    data = (
+        '{"customer_id": "", "x": 1.2, "d":"2001-01-01"}\n'
+        '{"customer_id": "23456", "x": 2.3, "d":"2001-01-03"}\n'
+        '{"customer_id": "34567", "x": 3.4, "d":"2001-01-05"}\n'
+    )
+    out_stream = to_json_file(data)
+    # Act
+    out, stats = delete_matches_from_json_file(out_stream, to_delete)
+    assert isinstance(out, pa.BufferOutputStream)
+    assert {"ProcessedRows": 3, "DeletedRows": 1} == stats
+    assert to_json_string(out) == (
+        '{"customer_id": "23456", "x": 2.3, "d":"2001-01-03"}\n'
+        '{"customer_id": "34567", "x": 3.4, "d":"2001-01-05"}\n'
+    )
+
+
+def test_delete_correct_rows_from_json_file_with_falsy_boolean_identifier():
+    # Arrange
+    to_delete = [{"Column": "opted_in", "MatchIds": set([False]), "Type": "Simple"}]
+    data = (
+        '{"customer_id": "12345", "opted_in": false}\n'
+        '{"customer_id": "23456", "opted_in": true}\n'
+        '{"customer_id": "34567", "opted_in": true}\n'
+    )
+    out_stream = to_json_file(data)
+    # Act
+    out, stats = delete_matches_from_json_file(out_stream, to_delete)
+    assert isinstance(out, pa.BufferOutputStream)
+    assert {"ProcessedRows": 3, "DeletedRows": 1} == stats
+    assert to_json_string(out) == (
+        '{"customer_id": "23456", "opted_in": true}\n'
+        '{"customer_id": "34567", "opted_in": true}\n'
+    )
+
+
+def test_delete_correct_rows_from_json_file_with_composite_types_falsy_component():
+    # Arrange
+    to_delete = [
+        {
+            "Columns": ["age", "last_name"],
+            "MatchIds": set([tuple([0, "Doe"])]),
+            "Type": "Composite",
+        }
+    ]
+    data = (
+        '{"customer_id": 12345, "last_name": "Doe", "age": 0}\n'
+        '{"customer_id": 23456, "last_name": "Doe", "age": 12}\n'
+        '{"customer_id": 34567, "last_name": "Hey", "age": 0}\n'
+    )
+    out_stream = to_json_file(data)
+    # Act
+    out, stats = delete_matches_from_json_file(out_stream, to_delete)
+    assert isinstance(out, pa.BufferOutputStream)
+    assert {"ProcessedRows": 3, "DeletedRows": 1} == stats
+    assert to_json_string(out) == (
+        '{"customer_id": 23456, "last_name": "Doe", "age": 12}\n'
+        '{"customer_id": 34567, "last_name": "Hey", "age": 0}\n'
+    )
+
+
 def to_json_file(data, compressed=False):
     mode = "wb" if compressed else "w+t"
     tmp = tempfile.NamedTemporaryFile(mode=mode)


### PR DESCRIPTION
## Problem

The JSON Forget-phase handler (`delete_matches_from_json_file`) silently fails to delete records whose match identifier is a legitimate falsy JSON value — empty string `""`, integer `0`/float `0.0`, or boolean `false`. The matching record is written back to the output instead of being removed.

**The Composite case is the one that matters in practice.** Composite matches exist for datasets where no single column is unique, so the tuple components are ordinary attributes where falsy values are entirely plausible (`age: 0`, an empty optional name field). A falsy component was dropped from the reconstructed `matched` tuple, producing a malformed shorter tuple that no longer equals any entry in `MatchIds` — so a record that genuinely matches a deletion request is not erased.

The Simple case is the same bug but largely theoretical: Simple Match IDs are personal identifiers, where a real erasure request for `userid=0` or `""` isn't a scenario we realistically expect. The code was still wrong there (and inconsistent with the Parquet handler, which casts and compares falsy values correctly), so the fix covers it too.

## Root cause

Both comparison sites used Python truthiness rather than an explicit presence check:

- **Composite:** `if record:` — a falsy component is dropped from the `matched` list, so the reconstructed tuple no longer equals any entry in `MatchIds`.
- **Simple:** `if record and record in column["MatchIds"]:` — the `record and` clause short-circuits whenever `record` is falsy-but-present, so `0`/`""`/`false` never reach the membership test.

The `None` sentinel returned by `get_value`/`find_key` means **only** that a key segment is **absent**. So `is not None` is the precise predicate: it preserves the original intent (skip absent keys) while correctly admitting falsy-but-present values. This is the absent-vs-falsy distinction the truthiness guard conflated. (The Parquet path casts column values before comparison; the JSON path passes Match IDs through with native parsed types, which is why falsy natives leak into the guard here.)

## Fix

Two one-token changes:

- `if record:` → `if record is not None:`
- `if record and record in column["MatchIds"]:` → `if record is not None and record in column["MatchIds"]:`

## Testing

Added 4 unit tests in `tests/unit/ecs_tasks/test_json.py` — a Composite match with a `0` component (the case that matters), plus Simple `0`, Simple `""`, and Simple `false`; each asserts the matching record IS deleted. They fail on `master` (record survives, `DeletedRows: 0`) and pass after the fix. Full `test_json.py` (18) and the entire `tests/unit/ecs_tasks/` suite pass, including the existing nullable/undefined tests that pin absent-key behavior.

> The Simple `false` test is defensive coverage only — `boolean` is not in `ALLOWED_TYPES`, so a boolean column can never be selected as an identifier (`cast_to_type` would reject it upstream). The test is annotated to say so; it pins the handler's `is not None` semantics independent of the type rules.

## Risk

Low and tightly scoped. The only behavior change is that falsy-but-present identifiers now match. Absent keys still short-circuit (still `None`, still skipped) — guarded by pre-existing tests. No public API or signature change.

> No issue to close — this is an unreported bug found by reading the code. An alternative fix would align the JSON path with the Parquet path's explicit type-casting; I chose the minimal `is not None` guard as it directly targets the defect — flag if you'd prefer the casting approach.
