### PR TITLE
Remove libaom3 to address CVE-2026-56209

### DIFF
--- a/backend/ecs_tasks/delete_files/Dockerfile
+++ b/backend/ecs_tasks/delete_files/Dockerfile
@@ -5,7 +5,7 @@ FROM public.ecr.aws/docker/library/python:3.12.12-slim-bookworm AS base
 
 RUN apt-get update --fix-missing && apt-get -y upgrade
 RUN apt-get -y install g++ gcc libsnappy-dev
-RUN apt-get remove -y sqlite3 libsqlite3-0 libsqlite3-dev && \
+RUN apt-get remove -y sqlite3 libsqlite3-0 libsqlite3-dev libaom3 && \
     apt-get autoremove -y && \
     apt-get autoclean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
*Issue #, if available:*
CVE-2026-56209 - Critical Remote Code Execution vulnerability in libaom3 (AV1 codec)
*Description of changes:*
The issue is related to the risk : https://shepherd.a2z.com/issues/80544f0e-300c-47ff-96ac-0d382724b4fb?view=aaky
as sev2 we received at our end We have only 3 days left before it escalate

Added `libaom3` to the apt-get remove line in the Dockerfile to address CVE-2026-56209.
  
- **CVE:** CVE-2026-56209 (Critical - arbitrary address write in libaom's SVC encoder path)
- **No upstream fix available:** All Debian releases (bullseye, bookworm, trixie, sid) are marked vulnerable with no fix timeline published
- **Package is unused by S3F2:** libaom3 is a video codec library pulled in as a transitive dependency (libsnappy-dev → libc-devtools → libgd3 → libheif1 → libaom3). 

*Testing*
- Verified `apt rdepends --installed libaom3` → only image codec libs (libavif15, libheif1), not used by S3F2
- Built image with the change → clean build
- Confirmed `dpkg -l | grep libaom` returns empty after build
- Core imports (pyarrow, boto3) work fine
- main.py loads successfully


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
