### PR TITLE
Release v0.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## v0.75 (2026-07-07)
+
+- [#455](https://github.com/awslabs/amazon-s3-find-and-forget/pull/455): Remove
+  libaom3 to address CVE-2026-56209
+- [#454](https://github.com/awslabs/amazon-s3-find-and-forget/pull/454): Bump
+  cryptography in /backend/ecs_tasks/delete_files
+- [#452](https://github.com/awslabs/amazon-s3-find-and-forget/pull/452): Bump
+  idna from 3.11 to 3.15
+- [#450](https://github.com/awslabs/amazon-s3-find-and-forget/pull/450): Bump
+  urllib3 from 2.6.3 to 2.7.0 in /backend/ecs_tasks/delete_files
+- [#449](https://github.com/awslabs/amazon-s3-find-and-forget/pull/449): Bump
+  pytest from 7.2.0 to 9.0.3
+- [#448](https://github.com/awslabs/amazon-s3-find-and-forget/pull/448): Bump
+  requests from 2.32.5 to 2.33.0
+- [#447](https://github.com/awslabs/amazon-s3-find-and-forget/pull/447): Bump
+  black from 24.3.0 to 26.3.1
+
 ## v0.74 (2026-03-11)
 
 - [#443](https://github.com/awslabs/amazon-s3-find-and-forget/pull/443): Upgrade

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.74) (tag:main)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.75) (tag:main)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.74'
+      Version: 'v0.75'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
## Summary

Prepares the v0.75 release.

- Update CHANGELOG.md with v0.75 entries (PRs #447-#455)
- Bump solution version from v0.74 to v0.75 in `templates/template.yaml`

## Changes included in v0.75

- #455: Remove libaom3 to address CVE-2026-56209
- #454: Bump cryptography in /backend/ecs_tasks/delete_files
- #452: Bump idna from 3.11 to 3.15
- #450: Bump urllib3 from 2.6.3 to 2.7.0 in /backend/ecs_tasks/delete_files
- #449: Bump pytest from 7.2.0 to 9.0.3
- #448: Bump requests from 2.32.5 to 2.33.0
- #447: Bump black from 24.3.0 to 26.3.1

## Testing

Version bump and changelog only; no functional code changes.