### PR TITLE
Release v0.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.76 (2026-07-07)
+
+- [#457](https://github.com/awslabs/amazon-s3-find-and-forget/pull/457): Bump
+  bootstrap from 4.6.1 to 4.6.2 to fix the frontend build
+
 ## v0.75 (2026-07-07)
 
 - [#455](https://github.com/awslabs/amazon-s3-find-and-forget/pull/455): Remove

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "aws-amplify": "^4.3.26",
-    "bootstrap": "^4.6.1",
+    "bootstrap": "^4.6.2",
     "react": "^17.0.2",
     "react-bootstrap": "^1.6.4",
     "react-dom": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
         "aws-amplify": "^4.3.26",
-        "bootstrap": "^4.6.1",
+        "bootstrap": "^4.6.2",
         "react": "^17.0.2",
         "react-bootstrap": "^1.6.4",
         "react-dom": "^17.0.2",
@@ -5450,17 +5450,6 @@
       "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/@types/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-tBFxBp9Nfyy5rsmefN+WXc1JeW/j2BpBHFdLZbEVfs9wn3E3NRFxwV0pJg8M1qQAexFpvz73hJXFofV0ZAu92A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/@types/yargs": {
@@ -12493,13 +12482,21 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"
@@ -30726,16 +30723,6 @@
             "@sinonjs/commons": "^3.0.0"
           }
         },
-        "@types/react": {
-          "version": "19.2.4",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.4.tgz",
-          "integrity": "sha512-tBFxBp9Nfyy5rsmefN+WXc1JeW/j2BpBHFdLZbEVfs9wn3E3NRFxwV0pJg8M1qQAexFpvz73hJXFofV0ZAu92A==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "csstype": "^3.0.2"
-          }
-        },
         "@types/yargs": {
           "version": "17.0.34",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.34.tgz",
@@ -35271,7 +35258,7 @@
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
         "aws-amplify": "^4.3.26",
-        "bootstrap": "^4.6.1",
+        "bootstrap": "^4.6.2",
         "react": "^17.0.2",
         "react-bootstrap": "^1.6.4",
         "react-dom": "^17.0.2",
@@ -35867,9 +35854,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
       "requires": {}
     },
     "bowser": {

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.75) (tag:main)
+Description: Amazon S3 Find and Forget (uksb-1q2j8beb0) (version:v0.76) (tag:main)
 
 Parameters:
   AccessControlAllowOriginOverride:
@@ -206,7 +206,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.75'
+      Version: 'v0.76'
 
 Resources:
   TempBucket:


### PR DESCRIPTION
## Summary

Prepares the v0.76 release.

- Update CHANGELOG.md with v0.76 entry
- Bump bootstrap from 4.6.1 to 4.6.2 to fix the frontend build (previously committed as `32f3e58`, not included in the v0.75 release PR)
- Bump solution version from v0.75 to v0.76 in `templates/template.yaml`

## Changes included in v0.76

- Bump bootstrap from 4.6.1 to 4.6.2 to fix the frontend build

## Testing

Version bump, dependency patch, and changelog only; no functional code changes.